### PR TITLE
fix: use rule_id instead of id in alert_rule_edit tool

### DIFF
--- a/src/librenms_mcp/librenms_tools.py
+++ b/src/librenms_mcp/librenms_tools.py
@@ -331,8 +331,8 @@ Example:
         payload: Annotated[
             dict,
             Field(
-                description="""Alert rule edit payload (must include id field):
-- id (required): Rule ID to edit
+                description="""Alert rule edit payload (must include rule_id field):
+- rule_id (required): Rule ID to edit
 - name: Rule name
 - builder: Rule builder JSON with conditions
 - devices: Array of device IDs or [-1] for all devices
@@ -358,7 +358,7 @@ Example:
             dict: The JSON response from the API.
         """
         try:
-            await ctx.info(f"Editing rule {payload.get('id')}...")
+            await ctx.info(f"Editing rule {payload.get('rule_id')}...")
 
             async with LibreNMSClient(config) as client:
                 return await client.put("rules", data=payload)


### PR DESCRIPTION
## Summary
- Fix `alert_rule_edit` tool to document `rule_id` instead of `id` as the required field name
- The LibreNMS API's `add_edit_rule` function checks for `$data['rule_id']` (not `$data['id']`) to determine if it should update vs create a rule
- When `rule_id` is missing/non-numeric, the API silently creates a new rule instead of editing the intended one

## Test plan
- [x] Verify `alert_rule_edit` tool description shows `rule_id` as the required field
- [x] Verify the `ctx.info` log message references `rule_id`
- [x] Confirm existing tests pass (`pytest tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)