### PR TITLE
feat: add sensor and health management tools

### DIFF
--- a/src/librenms_mcp/librenms_tools.py
+++ b/src/librenms_mcp/librenms_tools.py
@@ -3550,9 +3550,7 @@ Example: {"type": "http", "desc": "Web Server", "param": "-p 8080 -u /health"}""
         hostname: Annotated[str, Field(description="Device hostname or ID")],
         type: Annotated[
             str,
-            Field(
-                description="Sensor type (e.g. temperature, voltage, fanspeed)"
-            ),
+            Field(description="Sensor type (e.g. temperature, voltage, fanspeed)"),
         ],
         ctx: Context = None,
     ) -> dict:
@@ -3575,9 +3573,7 @@ Example: {"type": "http", "desc": "Web Server", "param": "-p 8080 -u /health"}""
                 )
 
         except Exception as e:
-            await ctx.error(
-                f"Error getting {type} health data for {hostname}: {e!s}"
-            )
+            await ctx.error(f"Error getting {type} health data for {hostname}: {e!s}")
             return {"error": str(e)}
 
     @mcp.tool(
@@ -3592,9 +3588,7 @@ Example: {"type": "http", "desc": "Web Server", "param": "-p 8080 -u /health"}""
         hostname: Annotated[str, Field(description="Device hostname or ID")],
         type: Annotated[
             str,
-            Field(
-                description="Sensor type (e.g. temperature, voltage, fanspeed)"
-            ),
+            Field(description="Sensor type (e.g. temperature, voltage, fanspeed)"),
         ],
         sensor_id: Annotated[int, Field(ge=1, description="Sensor ID")],
         ctx: Context = None,
@@ -3611,9 +3605,7 @@ Example: {"type": "http", "desc": "Web Server", "param": "-p 8080 -u /health"}""
             dict: The JSON response from the API.
         """
         try:
-            await ctx.info(
-                f"Getting sensor {sensor_id} ({type}) for {hostname}..."
-            )
+            await ctx.info(f"Getting sensor {sensor_id} ({type}) for {hostname}...")
 
             async with LibreNMSClient(config) as client:
                 return await client.get(


### PR DESCRIPTION
## Summary
- Add `health_list` tool to list available health graphs for a device (`GET /devices/{hostname}/health`)
- Add `health_by_type` tool to get health data by sensor type (`GET /devices/{hostname}/health/{type}`)
- Add `health_sensor_get` tool to get a specific sensor by ID (`GET /devices/{hostname}/health/{type}/{sensor_id}`)
- Add `sensors_list` tool to list all sensors across all devices (`GET /resources/sensors`)

All four tools are read-only and follow existing codebase patterns.

## Test plan
- [ ] Verify all four tools are registered with correct tags and annotations
- [ ] Verify `health_by_type` and `health_sensor_get` URL-encode the sensor type parameter
- [ ] Confirm existing tests pass (`pytest tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)