### PR TITLE
feat: add snmp_disable support to device_update

### DIFF
--- a/src/librenms_mcp/librenms_tools.py
+++ b/src/librenms_mcp/librenms_tools.py
@@ -1292,6 +1292,7 @@ Valid type values: all, active, ignored, up, down, disabled, os, mac, ipv4, ipv6
 - poller_group: Poller group ID
 - ignore: 0/1 to ignore device in alerts
 - disabled: 0/1 to disable polling
+- snmp_disable: 0/1 to disable SNMP polling
 - display: Custom display name
 - type: Device type classification"""
             ),
@@ -1312,7 +1313,7 @@ Valid type values: all, active, ignored, up, down, disabled, os, mac, ipv4, ipv6
             await ctx.info(f"Updating device {hostname}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.put(f"devices/{hostname}", data=payload)
+                return await client.patch(f"devices/{hostname}", data=payload)
 
         except Exception as e:
             await ctx.error(f"Error updating device {hostname}: {e!s}")


### PR DESCRIPTION
## Summary
- Add `snmp_disable` (0/1) to the documented patchable fields for `device_update`, matching the SNMP On/Off toggle in the LibreNMS GUI
- Switch `device_update` from `PUT` to `PATCH`, which is the correct HTTP verb for partial device updates in the LibreNMS API

## Test plan
- [ ] Verify `device_update` tool description includes `snmp_disable`
- [ ] Test disabling SNMP on a device: `device_update("hostname", {"field": ["snmp_disable"], "data": ["1"]})`
- [ ] Test re-enabling SNMP: `device_update("hostname", {"field": ["snmp_disable"], "data": ["0"]})`
- [ ] Confirm existing tests pass (`pytest tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)