### PR TITLE
feat: add Oxidized config backup tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,12 @@ MCP_HTTP_BEARER_TOKEN=
 - `bill_create_or_update`: Create or update a bill
 - `bill_delete`: Delete a bill
 
+### Oxidized Tools
+
+- `oxidized_list`: List devices tracked by Oxidized for config backup
+- `oxidized_config_get`: Get the stored configuration for a specific device
+- `oxidized_config_search`: Search all stored device configurations for a string
+
 ### Network & Monitoring Tools
 
 - `arp_search`: Search ARP entries

--- a/src/librenms_mcp/tools/__init__.py
+++ b/src/librenms_mcp/tools/__init__.py
@@ -8,6 +8,7 @@ from librenms_mcp.tools.inventory import register_inventory_tools
 from librenms_mcp.tools.locations import register_location_tools
 from librenms_mcp.tools.logs import register_logs_tools
 from librenms_mcp.tools.network import register_network_tools
+from librenms_mcp.tools.oxidized import register_oxidized_tools
 from librenms_mcp.tools.pollers import register_poller_tools
 from librenms_mcp.tools.ports import register_port_tools
 from librenms_mcp.tools.services import register_service_tools
@@ -24,6 +25,7 @@ def register_tools(mcp, config):
     register_location_tools(mcp, config)
     register_logs_tools(mcp, config)
     register_network_tools(mcp, config)
+    register_oxidized_tools(mcp, config)
     register_poller_tools(mcp, config)
     register_port_tools(mcp, config)
     register_service_tools(mcp, config)

--- a/src/librenms_mcp/tools/oxidized.py
+++ b/src/librenms_mcp/tools/oxidized.py
@@ -45,7 +45,10 @@ def register_oxidized_tools(mcp, config):
 
             async with LibreNMSClient(config) as client:
                 path = f"oxidized/{hostname}" if hostname else "oxidized"
-                return await client.get(path)
+                result = await client.get(path)
+                if isinstance(result, list):
+                    return {"devices": result}
+                return result
 
         except Exception as e:
             await ctx.error(f"Error listing Oxidized devices: {e!s}")
@@ -76,7 +79,10 @@ def register_oxidized_tools(mcp, config):
             await ctx.info(f"Getting Oxidized config for {hostname}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(f"oxidized/config/{hostname}")
+                result = await client.get(f"oxidized/config/{hostname}")
+                if isinstance(result, list):
+                    return {"configs": result}
+                return result
 
         except Exception as e:
             await ctx.error(f"Error getting Oxidized config for {hostname}: {e!s}")
@@ -112,7 +118,10 @@ def register_oxidized_tools(mcp, config):
             await ctx.info(f"Searching Oxidized configs for '{search}'...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(f"oxidized/config/search/{search}")
+                result = await client.get(f"oxidized/config/search/{search}")
+                if isinstance(result, list):
+                    return {"results": result}
+                return result
 
         except Exception as e:
             await ctx.error(f"Error searching Oxidized configs: {e!s}")

--- a/src/librenms_mcp/tools/oxidized.py
+++ b/src/librenms_mcp/tools/oxidized.py
@@ -1,0 +1,119 @@
+"""
+LibreNMS MCP Server Oxidized Tools
+"""
+
+from typing import Annotated
+
+from fastmcp.server.context import Context
+from pydantic import Field
+
+from librenms_mcp.librenms_client import LibreNMSClient
+
+
+def register_oxidized_tools(mcp, config):
+    """Register LibreNMS Oxidized tools with the MCP server"""
+    ##########################
+    # Oxidized Tools
+    ##########################
+
+    @mcp.tool(
+        tags={"librenms", "oxidized", "read-only"},
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        },
+    )
+    async def oxidized_list(
+        ctx: Context,
+        hostname: Annotated[
+            str | None,
+            Field(default=None, description="Filter by device hostname. Optional."),
+        ] = None,
+    ) -> dict:
+        """
+        List devices tracked by Oxidized for config backup.
+
+        Args:
+            hostname (str, optional): Filter by device hostname.
+
+        Returns:
+            dict: The JSON response from the API.
+        """
+        try:
+            await ctx.info("Listing Oxidized devices...")
+
+            async with LibreNMSClient(config) as client:
+                path = f"oxidized/{hostname}" if hostname else "oxidized"
+                return await client.get(path)
+
+        except Exception as e:
+            await ctx.error(f"Error listing Oxidized devices: {e!s}")
+            return {"error": str(e)}
+
+    @mcp.tool(
+        tags={"librenms", "oxidized", "read-only"},
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        },
+    )
+    async def oxidized_config_get(
+        hostname: Annotated[str, Field(description="Device hostname")],
+        ctx: Context,
+    ) -> dict:
+        """
+        Get the stored device configuration from Oxidized for a specific device.
+
+        Args:
+            hostname (str): Device hostname.
+
+        Returns:
+            dict: The JSON response from the API containing the device config.
+        """
+        try:
+            await ctx.info(f"Getting Oxidized config for {hostname}...")
+
+            async with LibreNMSClient(config) as client:
+                return await client.get(f"oxidized/config/{hostname}")
+
+        except Exception as e:
+            await ctx.error(f"Error getting Oxidized config for {hostname}: {e!s}")
+            return {"error": str(e)}
+
+    @mcp.tool(
+        tags={"librenms", "oxidized", "read-only"},
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        },
+    )
+    async def oxidized_config_search(
+        search: Annotated[
+            str,
+            Field(
+                description="Search string to look for in all stored device configs (e.g. an IP address, interface name, ACL name, or any config keyword)"
+            ),
+        ],
+        ctx: Context,
+    ) -> dict:
+        """
+        Search all Oxidized device configurations for a string.
+
+        Args:
+            search (str): Search string (IP, interface, ACL, keyword, etc.).
+
+        Returns:
+            dict: The JSON response from the API with matching devices and config snippets.
+        """
+        try:
+            await ctx.info(f"Searching Oxidized configs for '{search}'...")
+
+            async with LibreNMSClient(config) as client:
+                return await client.get(f"oxidized/config/search/{search}")
+
+        except Exception as e:
+            await ctx.error(f"Error searching Oxidized configs: {e!s}")
+            return {"error": str(e)}


### PR DESCRIPTION
## Summary

- Adds a new `oxidized.py` tool module with 3 tools for interacting with the Oxidized config backup integration
- `oxidized_list`: list all devices tracked by Oxidized (optional hostname filter)
- `oxidized_config_get`: retrieve the stored configuration for a specific device
- `oxidized_config_search`: search across all stored configs for any string (IP, interface, ACL, keyword, etc.)
- Updates `__init__.py` to register the new tools
- Updates README to document the new tools under Available Tools