### PR TITLE
fix(tools): URL-encode search queries and name parameters in API paths

### DIFF
--- a/src/librenms_mcp/tools/devices.py
+++ b/src/librenms_mcp/tools/devices.py
@@ -528,7 +528,9 @@ Example dynamic group:
             await ctx.info(f"Updating device group {name}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.patch(f"devicegroups/{name}", data=payload)
+                return await client.patch(
+                    f"devicegroups/{quote(name, safe='')}", data=payload
+                )
 
         except Exception as e:
             await ctx.error(f"Error updating device group {name}: {e!s}")
@@ -559,7 +561,7 @@ Example dynamic group:
             await ctx.info(f"Deleting device group {name}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.delete(f"devicegroups/{name}")
+                return await client.delete(f"devicegroups/{quote(name, safe='')}")
 
         except Exception as e:
             await ctx.error(f"Error deleting device group {name}: {e!s}")
@@ -603,7 +605,8 @@ Example dynamic group:
 
             async with LibreNMSClient(config) as client:
                 return await client.get(
-                    f"devicegroups/{name}", params=params if params else None
+                    f"devicegroups/{quote(name, safe='')}",
+                    params=params if params else None,
                 )
 
         except Exception as e:
@@ -647,7 +650,7 @@ Example dynamic group:
 
             async with LibreNMSClient(config) as client:
                 return await client.post(
-                    f"devicegroups/{name}/maintenance", data=payload
+                    f"devicegroups/{quote(name, safe='')}/maintenance", data=payload
                 )
 
         except Exception as e:
@@ -686,7 +689,9 @@ Example dynamic group:
             await ctx.info(f"Adding devices to group {name}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.post(f"devicegroups/{name}/devices", data=payload)
+                return await client.post(
+                    f"devicegroups/{quote(name, safe='')}/devices", data=payload
+                )
 
         except Exception as e:
             await ctx.error(f"Error adding devices to group {name}: {e!s}")
@@ -724,7 +729,9 @@ Example dynamic group:
             await ctx.info(f"Removing devices from group {name}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.delete(f"devicegroups/{name}/devices", data=payload)
+                return await client.delete(
+                    f"devicegroups/{quote(name, safe='')}/devices", data=payload
+                )
 
         except Exception as e:
             await ctx.error(f"Error removing devices from group {name}: {e!s}")
@@ -792,7 +799,9 @@ Example dynamic group:
             await ctx.info(f"Renaming device {hostname} to {new_hostname}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.patch(f"devices/{hostname}/rename/{new_hostname}")
+                return await client.patch(
+                    f"devices/{quote(hostname, safe='')}/rename/{quote(new_hostname, safe='')}"
+                )
 
         except Exception as e:
             await ctx.error(f"Error renaming device {hostname}: {e!s}")

--- a/src/librenms_mcp/tools/network.py
+++ b/src/librenms_mcp/tools/network.py
@@ -4,6 +4,7 @@ LibreNMS MCP Server Network Tools
 
 from typing import Annotated
 from typing import Any
+from urllib.parse import quote
 
 from fastmcp.server.context import Context
 from pydantic import Field
@@ -47,7 +48,7 @@ def register_network_tools(mcp, config):
             await ctx.info(f"Searching ARP entries with query: {query}")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(f"resources/ip/arp/{query}")
+                return await client.get(f"resources/ip/arp/{quote(query, safe='')}")
 
         except Exception as e:
             await ctx.error(f"Error ARP search {query}: {e!s}")
@@ -326,7 +327,7 @@ def register_network_tools(mcp, config):
             await ctx.info(f"Looking up FDB entry for MAC {mac}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(f"resources/fdb/{mac}")
+                return await client.get(f"resources/fdb/{quote(mac, safe='')}")
 
         except Exception as e:
             await ctx.error(f"Error looking up FDB for {mac}: {e!s}")

--- a/src/librenms_mcp/tools/oxidized.py
+++ b/src/librenms_mcp/tools/oxidized.py
@@ -3,6 +3,7 @@ LibreNMS MCP Server Oxidized Tools
 """
 
 from typing import Annotated
+from urllib.parse import quote
 
 from fastmcp.server.context import Context
 from pydantic import Field
@@ -44,7 +45,9 @@ def register_oxidized_tools(mcp, config):
             await ctx.info("Listing Oxidized devices...")
 
             async with LibreNMSClient(config) as client:
-                path = f"oxidized/{hostname}" if hostname else "oxidized"
+                path = (
+                    f"oxidized/{quote(hostname, safe='')}" if hostname else "oxidized"
+                )
                 result = await client.get(path)
                 if isinstance(result, list):
                     return {"devices": result}
@@ -79,7 +82,7 @@ def register_oxidized_tools(mcp, config):
             await ctx.info(f"Getting Oxidized config for {hostname}...")
 
             async with LibreNMSClient(config) as client:
-                result = await client.get(f"oxidized/config/{hostname}")
+                result = await client.get(f"oxidized/config/{quote(hostname, safe='')}")
                 if isinstance(result, list):
                     return {"configs": result}
                 return result
@@ -118,7 +121,9 @@ def register_oxidized_tools(mcp, config):
             await ctx.info(f"Searching Oxidized configs for '{search}'...")
 
             async with LibreNMSClient(config) as client:
-                result = await client.get(f"oxidized/config/search/{search}")
+                result = await client.get(
+                    f"oxidized/config/search/{quote(search, safe='')}"
+                )
                 if isinstance(result, list):
                     return {"results": result}
                 return result

--- a/src/librenms_mcp/tools/ports.py
+++ b/src/librenms_mcp/tools/ports.py
@@ -3,6 +3,7 @@ LibreNMS MCP Server Port Tools
 """
 
 from typing import Annotated
+from urllib.parse import quote
 
 from fastmcp.server.context import Context
 from pydantic import Field
@@ -88,7 +89,7 @@ Available columns: port_id, device_id, ifDescr, ifName, ifAlias, ifType, ifSpeed
             await ctx.info(f"Searching ports {search}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(f"ports/search/{search}")
+                return await client.get(f"ports/search/{quote(search, safe='')}")
 
         except Exception as e:
             await ctx.error(f"Error searching ports {search}: {e!s}")
@@ -126,7 +127,9 @@ Available columns: port_id, device_id, ifDescr, ifName, ifAlias, ifType, ifSpeed
             await ctx.info(f"Searching ports {field}={search}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(f"ports/search/{field}/{search}")
+                return await client.get(
+                    f"ports/search/{quote(field, safe='')}/{quote(search, safe='')}"
+                )
 
         except Exception as e:
             await ctx.error(f"Error field search {field}={search}: {e!s}")
@@ -162,7 +165,7 @@ Available columns: port_id, device_id, ifDescr, ifName, ifAlias, ifType, ifSpeed
             await ctx.info(f"Searching ports by MAC address {mac}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(f"ports/mac/{mac}")
+                return await client.get(f"ports/mac/{quote(mac, safe='')}")
 
         except Exception as e:
             await ctx.error(f"Error MAC search {mac}: {e!s}")
@@ -413,7 +416,7 @@ Available columns: port_id, device_id, ifDescr, ifName, ifAlias, ifType, ifSpeed
             await ctx.info(f"Getting ports in group {name}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(f"port_groups/{name}")
+                return await client.get(f"port_groups/{quote(name, safe='')}")
 
         except Exception as e:
             await ctx.error(f"Error listing ports in group {name}: {e!s}")


### PR DESCRIPTION
Imports and applies `urllib.parse.quote` to search terms, MAC addresses, and group names inside endpoint path interpolations. This prevents 404 and routing errors when parameters contain slashes, spaces, or colons.