### PR TITLE
feat(pagination): implement limit and offset pagination across list tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,9 +324,22 @@ MCP_HTTP_BEARER_TOKEN=
 - `switching_links`: List all links from LibreNMS.
 - `system_info`: Get system info from LibreNMS.
 
-### General Query Tools
-
 - Flexible filtering and search for all major resources (devices, ports, alerts, logs, inventory, etc.)
+
+## Pagination & Limit Support
+
+To prevent overloading LLM contexts when querying large LibreNMS production instances, all list, search, and log tools support pagination.
+
+### Key Features
+- **Sensible Defaults**: All list tools default to returning **100 results per page**.
+- **Unified Parameters**:
+  - `limit`: The maximum number of results to return (defaults to `100`, minimum `1`).
+  - `offset` (or `start` for log tools): The number of results to skip.
+- **Pagination Metadata**: Every paginated response includes metadata fields:
+  - `limit`: The active limit.
+  - `offset` (or `start`): The active offset.
+  - `count`: The number of items returned in the current page.
+  - `total`: The total number of items available (for log tools, this is provided if returned by the LibreNMS API).
 
 ## Security & Safety Features
 

--- a/src/librenms_mcp/tools/alerts.py
+++ b/src/librenms_mcp/tools/alerts.py
@@ -9,6 +9,7 @@ from fastmcp.server.context import Context
 from pydantic import Field
 
 from librenms_mcp.librenms_client import LibreNMSClient
+from librenms_mcp.utils import paginate_list
 
 
 def register_alert_tools(mcp, config):
@@ -54,6 +55,22 @@ def register_alert_tools(mcp, config):
                 description="How to order the output, default is by timestamp (descending). Can be appended by DESC or ASC to change the order. Optional.",
             ),
         ] = None,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         Get alerts from LibreNMS with optional filters.
@@ -63,6 +80,8 @@ def register_alert_tools(mcp, config):
             severity (str, optional): Filter the alerts by severity. Valid values: ok, warning, critical.
             alert_rule (int, optional): Filter alerts by alert rule ID.
             order (str, optional): How to order the output, default is by timestamp (descending). Can be appended by DESC or ASC.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -81,7 +100,8 @@ def register_alert_tools(mcp, config):
             await ctx.info("Retrieving alerts...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get("alerts", params=params)
+                result = await client.get("alerts", params=params)
+            return paginate_list(result, limit, offset, key="alerts")
 
         except Exception as e:
             await ctx.error(f"Error retrieving alerts: {e!s}")
@@ -219,7 +239,25 @@ def register_alert_tools(mcp, config):
             "idempotentHint": True,
         },
     )
-    async def alert_rules_list(ctx: Context) -> dict:
+    async def alert_rules_list(
+        ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
+    ) -> dict:
         """
         List all alert rules from LibreNMS.
 
@@ -230,7 +268,8 @@ def register_alert_tools(mcp, config):
             await ctx.info("Listing all alert rules...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get("rules")
+                result = await client.get("rules")
+            return paginate_list(result, limit, offset)
 
         except Exception as e:
             await ctx.error(f"Error listing rules: {e!s}")
@@ -408,7 +447,25 @@ Example:
             "idempotentHint": True,
         },
     )
-    async def alert_templates_list(ctx: Context) -> dict:
+    async def alert_templates_list(
+        ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
+    ) -> dict:
         """
         List all alert templates from LibreNMS.
 
@@ -419,7 +476,8 @@ Example:
             await ctx.info("Listing all alert templates...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get("templates")
+                result = await client.get("templates")
+            return paginate_list(result, limit, offset)
 
         except Exception as e:
             await ctx.error(f"Error listing alert templates: {e!s}")

--- a/src/librenms_mcp/tools/bills.py
+++ b/src/librenms_mcp/tools/bills.py
@@ -9,6 +9,7 @@ from fastmcp.server.context import Context
 from pydantic import Field
 
 from librenms_mcp.librenms_client import LibreNMSClient
+from librenms_mcp.utils import paginate_list
 
 
 def register_bill_tools(mcp, config):
@@ -40,6 +41,22 @@ def register_bill_tools(mcp, config):
         custid: Annotated[
             str | None, Field(default=None, description="Customer ID filter")
         ] = None,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         List bills from LibreNMS with optional filters.
@@ -48,6 +65,8 @@ def register_bill_tools(mcp, config):
             period (str, optional): List previous period bills.
             ref (str, optional): Bill reference filter.
             custid (str, optional): Customer ID filter.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -64,7 +83,8 @@ def register_bill_tools(mcp, config):
             await ctx.info("Listing bills...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get("bills", params=params or None)
+                result = await client.get("bills", params=params or None)
+            return paginate_list(result, limit, offset, key="bills")
 
         except Exception as e:
             await ctx.error(f"Error listing bills: {e!s}")
@@ -191,12 +211,30 @@ def register_bill_tools(mcp, config):
     async def bill_history(
         bill_id: Annotated[int, Field(ge=1)],
         ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         Get bill history from LibreNMS.
 
         Args:
             bill_id (int): Bill ID.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -205,7 +243,8 @@ def register_bill_tools(mcp, config):
             await ctx.info(f"Getting bill history {bill_id}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(f"bills/{bill_id}/history")
+                result = await client.get(f"bills/{bill_id}/history")
+            return paginate_list(result, limit, offset)
 
         except Exception as e:
             await ctx.error(f"Error bill history {bill_id}: {e!s}")

--- a/src/librenms_mcp/tools/devices.py
+++ b/src/librenms_mcp/tools/devices.py
@@ -10,6 +10,7 @@ from fastmcp.server.context import Context
 from pydantic import Field
 
 from librenms_mcp.librenms_client import LibreNMSClient
+from librenms_mcp.utils import paginate_list
 
 
 def register_device_tools(mcp, config):
@@ -37,12 +38,27 @@ def register_device_tools(mcp, config):
 - {"type": "os", "query": "linux"} - filter by operating system
 - {"type": "location", "query": "datacenter"} - filter by location
 - {"type": "up"} or {"type": "down"} - filter by status
-- {"limit": 50} - limit number of results
 - {"order": "hostname ASC"} - sort results
 
 Valid type values: all, active, ignored, up, down, disabled, os, mac, ipv4, ipv6, location, location_id, hostname, sysName, display, device_id, type, serial, version, hardware, features""",
             ),
         ] = None,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         List devices from LibreNMS with optional filters.
@@ -51,6 +67,8 @@ Valid type values: all, active, ignored, up, down, disabled, os, mac, ipv4, ipv6
             query (dict, optional): Query parameters for filtering. Use "type" to filter
                 by category (hostname, os, location, up, down, etc.) and "query" for
                 the search term. Can also include "limit" and "order".
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API containing device list.
@@ -59,7 +77,8 @@ Valid type values: all, active, ignored, up, down, disabled, os, mac, ipv4, ipv6
             await ctx.info("Listing devices...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get("devices", params=query)
+                result = await client.get("devices", params=query)
+            return paginate_list(result, limit, offset, key="devices")
 
         except Exception as e:
             await ctx.error(f"Error listing devices: {e!s}")
@@ -251,6 +270,22 @@ Valid type values: all, active, ignored, up, down, disabled, os, mac, ipv4, ipv6
                 description="Comma-separated list of columns to return (e.g., 'port_id,ifName,ifAlias,ifOperStatus')",
             ),
         ] = None,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         List ports for a device from LibreNMS.
@@ -258,6 +293,8 @@ Valid type values: all, active, ignored, up, down, disabled, os, mac, ipv4, ipv6
         Args:
             hostname (str): Device hostname or ID.
             columns (str, optional): Comma-separated columns to return.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -270,9 +307,10 @@ Valid type values: all, active, ignored, up, down, disabled, os, mac, ipv4, ipv6
             await ctx.info(f"Listing ports for {hostname}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(
+                result = await client.get(
                     f"devices/{hostname}/ports", params=params if params else None
                 )
+            return paginate_list(result, limit, offset, key="ports")
 
         except Exception as e:
             await ctx.error(f"Error listing ports for {hostname}: {e!s}")
@@ -351,12 +389,33 @@ Valid type values: all, active, ignored, up, down, disabled, os, mac, ipv4, ipv6
             "idempotentHint": True,
         },
     )
-    async def device_outages(hostname: Annotated[str, Field()], ctx: Context) -> dict:
+    async def device_outages(
+        hostname: Annotated[str, Field()],
+        ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
+    ) -> dict:
         """
         Get device outages from LibreNMS.
 
         Args:
             hostname (str): Device hostname.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -365,7 +424,8 @@ Valid type values: all, active, ignored, up, down, disabled, os, mac, ipv4, ipv6
             await ctx.info(f"Getting outages for {hostname}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(f"devices/{hostname}/outages")
+                result = await client.get(f"devices/{hostname}/outages")
+            return paginate_list(result, limit, offset, key="outages")
 
         except Exception as e:
             await ctx.error(f"Error outages {hostname}: {e!s}")
@@ -427,7 +487,25 @@ Valid type values: all, active, ignored, up, down, disabled, os, mac, ipv4, ipv6
             "idempotentHint": True,
         },
     )
-    async def devicegroups_list(ctx: Context) -> dict:
+    async def devicegroups_list(
+        ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
+    ) -> dict:
         """
         List all device groups from LibreNMS.
 
@@ -438,7 +516,8 @@ Valid type values: all, active, ignored, up, down, disabled, os, mac, ipv4, ipv6
             await ctx.info("Getting device groups...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get("devicegroups")
+                result = await client.get("devicegroups")
+            return paginate_list(result, limit, offset)
 
         except Exception as e:
             await ctx.error(f"Error listing device groups: {e!s}")
@@ -585,6 +664,22 @@ Example dynamic group:
                 description="Set to true to get complete device data instead of just IDs",
             ),
         ] = None,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         List devices in a device group from LibreNMS.
@@ -592,6 +687,8 @@ Example dynamic group:
         Args:
             name (str): Device group name.
             full (bool, optional): If true, returns full device details.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -604,10 +701,11 @@ Example dynamic group:
             await ctx.info(f"Listing devices in group {name}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(
+                result = await client.get(
                     f"devicegroups/{quote(name, safe='')}",
                     params=params if params else None,
                 )
+            return paginate_list(result, limit, offset)
 
         except Exception as e:
             await ctx.error(f"Error listing devices in group {name}: {e!s}")
@@ -849,12 +947,30 @@ Example dynamic group:
     async def device_vlans(
         hostname: Annotated[str, Field(description="Device hostname or ID")],
         ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         Get VLANs configured on a specific device.
 
         Args:
             hostname (str): Device hostname or ID.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -863,7 +979,8 @@ Example dynamic group:
             await ctx.info(f"Getting VLANs for {hostname}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(f"devices/{hostname}/vlans")
+                result = await client.get(f"devices/{hostname}/vlans")
+            return paginate_list(result, limit, offset)
 
         except Exception as e:
             await ctx.error(f"Error getting VLANs for {hostname}: {e!s}")
@@ -880,12 +997,30 @@ Example dynamic group:
     async def device_links(
         hostname: Annotated[str, Field(description="Device hostname or ID")],
         ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         Get network links for a specific device.
 
         Args:
             hostname (str): Device hostname or ID.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -894,7 +1029,8 @@ Example dynamic group:
             await ctx.info(f"Getting links for {hostname}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(f"devices/{hostname}/links")
+                result = await client.get(f"devices/{hostname}/links")
+            return paginate_list(result, limit, offset)
 
         except Exception as e:
             await ctx.error(f"Error getting links for {hostname}: {e!s}")

--- a/src/librenms_mcp/tools/health.py
+++ b/src/librenms_mcp/tools/health.py
@@ -9,6 +9,7 @@ from fastmcp.server.context import Context
 from pydantic import Field
 
 from librenms_mcp.librenms_client import LibreNMSClient
+from librenms_mcp.utils import paginate_list
 
 
 def register_health_tools(mcp, config):
@@ -28,12 +29,30 @@ def register_health_tools(mcp, config):
     async def health_list(
         hostname: Annotated[str, Field(description="Device hostname or ID")],
         ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         List available health graphs for a device.
 
         Args:
             hostname (str): Device hostname or ID.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -42,7 +61,8 @@ def register_health_tools(mcp, config):
             await ctx.info(f"Getting health graphs for {hostname}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(f"devices/{hostname}/health")
+                result = await client.get(f"devices/{hostname}/health")
+            return paginate_list(result, limit, offset)
 
         except Exception as e:
             await ctx.error(f"Error getting health graphs for {hostname}: {e!s}")
@@ -63,6 +83,22 @@ def register_health_tools(mcp, config):
             Field(description="Sensor type (e.g. temperature, voltage, fanspeed)"),
         ],
         ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         Get health data by sensor type for a device.
@@ -70,6 +106,8 @@ def register_health_tools(mcp, config):
         Args:
             hostname (str): Device hostname or ID.
             type (str): Sensor type (e.g. temperature, voltage, fanspeed).
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -78,9 +116,10 @@ def register_health_tools(mcp, config):
             await ctx.info(f"Getting {type} health data for {hostname}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(
+                result = await client.get(
                     f"devices/{hostname}/health/{quote(type, safe='')}"
                 )
+            return paginate_list(result, limit, offset)
 
         except Exception as e:
             await ctx.error(f"Error getting {type} health data for {hostname}: {e!s}")
@@ -138,9 +177,29 @@ def register_health_tools(mcp, config):
     )
     async def sensors_list(
         ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         List all sensors across all devices.
+
+        Args:
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -149,7 +208,8 @@ def register_health_tools(mcp, config):
             await ctx.info("Listing all sensors...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get("resources/sensors")
+                result = await client.get("resources/sensors")
+            return paginate_list(result, limit, offset, key="sensors")
 
         except Exception as e:
             await ctx.error(f"Error listing sensors: {e!s}")

--- a/src/librenms_mcp/tools/inventory.py
+++ b/src/librenms_mcp/tools/inventory.py
@@ -9,6 +9,7 @@ from fastmcp.server.context import Context
 from pydantic import Field
 
 from librenms_mcp.librenms_client import LibreNMSClient
+from librenms_mcp.utils import paginate_list
 
 
 def register_inventory_tools(mcp, config):
@@ -42,6 +43,22 @@ def register_inventory_tools(mcp, config):
                 description="Filter by parent entity index",
             ),
         ] = None,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         Get inventory for a device from LibreNMS.
@@ -50,6 +67,8 @@ def register_inventory_tools(mcp, config):
             hostname (str): Device hostname or ID.
             ent_physical_class (str, optional): Filter by entity physical class.
             ent_physical_contained_in (int, optional): Filter by parent entity.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -64,9 +83,10 @@ def register_inventory_tools(mcp, config):
             await ctx.info(f"Getting inventory for {hostname}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(
+                result = await client.get(
                     f"inventory/{hostname}", params=params if params else None
                 )
+            return paginate_list(result, limit, offset, key="inventory")
 
         except Exception as e:
             await ctx.error(f"Error inventory {hostname}: {e!s}")
@@ -81,13 +101,32 @@ def register_inventory_tools(mcp, config):
         },
     )
     async def inventory_device_flat(
-        hostname: Annotated[str, Field()], ctx: Context
+        hostname: Annotated[str, Field()],
+        ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         Get flattened inventory for a device from LibreNMS.
 
         Args:
             hostname (str): Device hostname.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -96,7 +135,8 @@ def register_inventory_tools(mcp, config):
             await ctx.info(f"Getting flattened inventory for {hostname}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(f"inventory/{hostname}/all")
+                result = await client.get(f"inventory/{hostname}/all")
+            return paginate_list(result, limit, offset, key="inventory")
 
         except Exception as e:
             await ctx.error(f"Error inventory flat {hostname}: {e!s}")

--- a/src/librenms_mcp/tools/locations.py
+++ b/src/librenms_mcp/tools/locations.py
@@ -9,6 +9,7 @@ from fastmcp.server.context import Context
 from pydantic import Field
 
 from librenms_mcp.librenms_client import LibreNMSClient
+from librenms_mcp.utils import paginate_list
 
 
 def register_location_tools(mcp, config):
@@ -25,9 +26,31 @@ def register_location_tools(mcp, config):
             "idempotentHint": True,
         },
     )
-    async def locations_list(ctx: Context) -> dict:
+    async def locations_list(
+        ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
+    ) -> dict:
         """
         List locations from LibreNMS.
+
+        Args:
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -36,7 +59,8 @@ def register_location_tools(mcp, config):
             await ctx.info("Listing locations...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get("resources/locations")
+                result = await client.get("resources/locations")
+            return paginate_list(result, limit, offset, key="locations")
 
         except Exception as e:
             await ctx.error(f"Error listing locations: {e!s}")

--- a/src/librenms_mcp/tools/logs.py
+++ b/src/librenms_mcp/tools/logs.py
@@ -29,13 +29,21 @@ def register_logs_tools(mcp, config):
         ctx: Context,
         hostname: Annotated[str, Field(description="Device hostname or ID")],
         start: Annotated[
-            int | None,
-            Field(default=None, description="Page number for pagination"),
-        ] = None,
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
         limit: Annotated[
-            int | None,
-            Field(default=None, description="Maximum number of results to return"),
-        ] = None,
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
         from_ts: Annotated[
             str | None,
             Field(
@@ -60,8 +68,8 @@ def register_logs_tools(mcp, config):
 
         Args:
             hostname (str): Device hostname or ID.
-            start (int, optional): Page number.
-            limit (int, optional): Max results.
+            start (int): Number of results to skip.
+            limit (int): Max results.
             from_ts (str, optional): Start timestamp.
             to_ts (str, optional): End timestamp.
             sortorder (str, optional): ASC or DESC.
@@ -69,11 +77,10 @@ def register_logs_tools(mcp, config):
         Returns:
             dict: The JSON response from the API.
         """
-        params: dict[str, Any] = {}
-        if start is not None:
-            params["start"] = start
-        if limit is not None:
-            params["limit"] = limit
+        params: dict[str, Any] = {
+            "start": start,
+            "limit": limit,
+        }
         if from_ts is not None:
             params["from"] = from_ts
         if to_ts is not None:
@@ -85,9 +92,15 @@ def register_logs_tools(mcp, config):
             await ctx.info(f"Getting event logs for {hostname}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(
-                    f"logs/eventlog/{hostname}", params=params if params else None
-                )
+                result = await client.get(f"logs/eventlog/{hostname}", params=params)
+
+            if isinstance(result, dict) and result.get("status") == "ok":
+                list_keys = [k for k, v in result.items() if isinstance(v, list)]
+                count = len(result[list_keys[0]]) if list_keys else 0
+                result["count"] = count
+                result["limit"] = limit
+                result["start"] = start
+            return result
 
         except Exception as e:
             await ctx.error(f"Error eventlog {hostname}: {e!s}")
@@ -105,13 +118,21 @@ def register_logs_tools(mcp, config):
         ctx: Context,
         hostname: Annotated[str, Field(description="Device hostname or ID")],
         start: Annotated[
-            int | None,
-            Field(default=None, description="Page number for pagination"),
-        ] = None,
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
         limit: Annotated[
-            int | None,
-            Field(default=None, description="Maximum number of results to return"),
-        ] = None,
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
         from_ts: Annotated[
             str | None,
             Field(
@@ -136,8 +157,8 @@ def register_logs_tools(mcp, config):
 
         Args:
             hostname (str): Device hostname or ID.
-            start (int, optional): Page number.
-            limit (int, optional): Max results.
+            start (int): Number of results to skip.
+            limit (int): Max results.
             from_ts (str, optional): Start timestamp.
             to_ts (str, optional): End timestamp.
             sortorder (str, optional): ASC or DESC.
@@ -145,11 +166,10 @@ def register_logs_tools(mcp, config):
         Returns:
             dict: The JSON response from the API.
         """
-        params: dict[str, Any] = {}
-        if start is not None:
-            params["start"] = start
-        if limit is not None:
-            params["limit"] = limit
+        params: dict[str, Any] = {
+            "start": start,
+            "limit": limit,
+        }
         if from_ts is not None:
             params["from"] = from_ts
         if to_ts is not None:
@@ -161,9 +181,15 @@ def register_logs_tools(mcp, config):
             await ctx.info(f"Getting syslogs for {hostname}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(
-                    f"logs/syslog/{hostname}", params=params if params else None
-                )
+                result = await client.get(f"logs/syslog/{hostname}", params=params)
+
+            if isinstance(result, dict) and result.get("status") == "ok":
+                list_keys = [k for k, v in result.items() if isinstance(v, list)]
+                count = len(result[list_keys[0]]) if list_keys else 0
+                result["count"] = count
+                result["limit"] = limit
+                result["start"] = start
+            return result
 
         except Exception as e:
             await ctx.error(f"Error syslog {hostname}: {e!s}")
@@ -181,13 +207,21 @@ def register_logs_tools(mcp, config):
         ctx: Context,
         hostname: Annotated[str, Field(description="Device hostname or ID")],
         start: Annotated[
-            int | None,
-            Field(default=None, description="Page number for pagination"),
-        ] = None,
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
         limit: Annotated[
-            int | None,
-            Field(default=None, description="Maximum number of results to return"),
-        ] = None,
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
         from_ts: Annotated[
             str | None,
             Field(
@@ -212,8 +246,8 @@ def register_logs_tools(mcp, config):
 
         Args:
             hostname (str): Device hostname or ID.
-            start (int, optional): Page number.
-            limit (int, optional): Max results.
+            start (int): Number of results to skip.
+            limit (int): Max results.
             from_ts (str, optional): Start timestamp.
             to_ts (str, optional): End timestamp.
             sortorder (str, optional): ASC or DESC.
@@ -221,11 +255,10 @@ def register_logs_tools(mcp, config):
         Returns:
             dict: The JSON response from the API.
         """
-        params: dict[str, Any] = {}
-        if start is not None:
-            params["start"] = start
-        if limit is not None:
-            params["limit"] = limit
+        params: dict[str, Any] = {
+            "start": start,
+            "limit": limit,
+        }
         if from_ts is not None:
             params["from"] = from_ts
         if to_ts is not None:
@@ -237,9 +270,15 @@ def register_logs_tools(mcp, config):
             await ctx.info(f"Getting alert logs for {hostname}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(
-                    f"logs/alertlog/{hostname}", params=params if params else None
-                )
+                result = await client.get(f"logs/alertlog/{hostname}", params=params)
+
+            if isinstance(result, dict) and result.get("status") == "ok":
+                list_keys = [k for k, v in result.items() if isinstance(v, list)]
+                count = len(result[list_keys[0]]) if list_keys else 0
+                result["count"] = count
+                result["limit"] = limit
+                result["start"] = start
+            return result
 
         except Exception as e:
             await ctx.error(f"Error alertlog {hostname}: {e!s}")
@@ -256,13 +295,21 @@ def register_logs_tools(mcp, config):
     async def logs_authlog(
         ctx: Context,
         start: Annotated[
-            int | None,
-            Field(default=None, description="Page number for pagination"),
-        ] = None,
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
         limit: Annotated[
-            int | None,
-            Field(default=None, description="Maximum number of results to return"),
-        ] = None,
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
         from_ts: Annotated[
             str | None,
             Field(
@@ -287,8 +334,8 @@ def register_logs_tools(mcp, config):
 
         Args:
             hostname (str): Device hostname or ID.
-            start (int, optional): Page number.
-            limit (int, optional): Max results.
+            start (int): Number of results to skip.
+            limit (int): Max results.
             from_ts (str, optional): Start timestamp.
             to_ts (str, optional): End timestamp.
             sortorder (str, optional): ASC or DESC.
@@ -296,11 +343,10 @@ def register_logs_tools(mcp, config):
         Returns:
             dict: The JSON response from the API.
         """
-        params: dict[str, Any] = {}
-        if start is not None:
-            params["start"] = start
-        if limit is not None:
-            params["limit"] = limit
+        params: dict[str, Any] = {
+            "start": start,
+            "limit": limit,
+        }
         if from_ts is not None:
             params["from"] = from_ts
         if to_ts is not None:
@@ -312,9 +358,15 @@ def register_logs_tools(mcp, config):
             await ctx.info("Getting auth logs ...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(
-                    "logs/authlog", params=params if params else None
-                )
+                result = await client.get("logs/authlog", params=params)
+
+            if isinstance(result, dict) and result.get("status") == "ok":
+                list_keys = [k for k, v in result.items() if isinstance(v, list)]
+                count = len(result[list_keys[0]]) if list_keys else 0
+                result["count"] = count
+                result["limit"] = limit
+                result["start"] = start
+            return result
 
         except Exception as e:
             await ctx.error(f"Error authlog: {e!s}")

--- a/src/librenms_mcp/tools/network.py
+++ b/src/librenms_mcp/tools/network.py
@@ -10,6 +10,7 @@ from fastmcp.server.context import Context
 from pydantic import Field
 
 from librenms_mcp.librenms_client import LibreNMSClient
+from librenms_mcp.utils import paginate_list
 
 
 def register_network_tools(mcp, config):
@@ -34,12 +35,30 @@ def register_network_tools(mcp, config):
             ),
         ],
         ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         Retrieve ARP entries from LibreNMS by search query.
 
         Args:
             query (str): Search string - IP, MAC, CIDR notation, or "all".
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -48,7 +67,8 @@ def register_network_tools(mcp, config):
             await ctx.info(f"Searching ARP entries with query: {query}")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(f"resources/ip/arp/{quote(query, safe='')}")
+                result = await client.get(f"resources/ip/arp/{quote(query, safe='')}")
+            return paginate_list(result, limit, offset)
 
         except Exception as e:
             await ctx.error(f"Error ARP search {query}: {e!s}")
@@ -109,6 +129,22 @@ def register_network_tools(mcp, config):
                 description="Filter by address family: 4 (IPv4) or 6 (IPv6)",
             ),
         ] = None,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         List BGP sessions from LibreNMS with optional filters.
@@ -140,7 +176,8 @@ def register_network_tools(mcp, config):
             await ctx.info("Listing BGP sessions...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get("bgp", params=params if params else None)
+                result = await client.get("bgp", params=params if params else None)
+            return paginate_list(result, limit, offset)
 
         except Exception as e:
             await ctx.error(f"Error listing BGP sessions: {e!s}")
@@ -222,7 +259,25 @@ def register_network_tools(mcp, config):
             "idempotentHint": True,
         },
     )
-    async def routing_ip_addresses(ctx: Context) -> dict:
+    async def routing_ip_addresses(
+        ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
+    ) -> dict:
         """
         List all IP addresses from LibreNMS.
 
@@ -233,7 +288,8 @@ def register_network_tools(mcp, config):
             await ctx.info("Listing IP addresses...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get("resources/ip/addresses")
+                result = await client.get("resources/ip/addresses")
+            return paginate_list(result, limit, offset)
 
         except Exception as e:
             await ctx.error(f"Error listing IP addresses: {e!s}")
@@ -251,7 +307,25 @@ def register_network_tools(mcp, config):
             "idempotentHint": True,
         },
     )
-    async def switching_vlans(ctx: Context) -> dict:
+    async def switching_vlans(
+        ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
+    ) -> dict:
         """
         List all VLANs from LibreNMS.
 
@@ -262,7 +336,8 @@ def register_network_tools(mcp, config):
             await ctx.info("Listing VLANs...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get("resources/vlans")
+                result = await client.get("resources/vlans")
+            return paginate_list(result, limit, offset)
 
         except Exception as e:
             await ctx.error(f"Error listing VLANs: {e!s}")
@@ -276,7 +351,25 @@ def register_network_tools(mcp, config):
             "idempotentHint": True,
         },
     )
-    async def switching_links(ctx: Context) -> dict:
+    async def switching_links(
+        ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
+    ) -> dict:
         """
         List all links from LibreNMS.
 
@@ -287,7 +380,8 @@ def register_network_tools(mcp, config):
             await ctx.info("Listing links...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get("resources/links")
+                result = await client.get("resources/links")
+            return paginate_list(result, limit, offset)
 
         except Exception as e:
             await ctx.error(f"Error listing links: {e!s}")
@@ -345,7 +439,25 @@ def register_network_tools(mcp, config):
             "idempotentHint": True,
         },
     )
-    async def ospf_list(ctx: Context) -> dict:
+    async def ospf_list(
+        ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
+    ) -> dict:
         """
         List all OSPF instances from LibreNMS.
 
@@ -356,7 +468,8 @@ def register_network_tools(mcp, config):
             await ctx.info("Listing OSPF instances...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get("ospf")
+                result = await client.get("ospf")
+            return paginate_list(result, limit, offset)
 
         except Exception as e:
             await ctx.error(f"Error listing OSPF: {e!s}")
@@ -370,7 +483,25 @@ def register_network_tools(mcp, config):
             "idempotentHint": True,
         },
     )
-    async def ospf_ports(ctx: Context) -> dict:
+    async def ospf_ports(
+        ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
+    ) -> dict:
         """
         List all OSPF ports/interfaces from LibreNMS.
 
@@ -381,7 +512,8 @@ def register_network_tools(mcp, config):
             await ctx.info("Listing OSPF ports...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get("ospf_ports")
+                result = await client.get("ospf_ports")
+            return paginate_list(result, limit, offset)
 
         except Exception as e:
             await ctx.error(f"Error listing OSPF ports: {e!s}")
@@ -399,7 +531,25 @@ def register_network_tools(mcp, config):
             "idempotentHint": True,
         },
     )
-    async def vrf_list(ctx: Context) -> dict:
+    async def vrf_list(
+        ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
+    ) -> dict:
         """
         List all VRF (Virtual Routing and Forwarding) instances from LibreNMS.
 
@@ -410,7 +560,8 @@ def register_network_tools(mcp, config):
             await ctx.info("Listing VRF instances...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get("routing/vrf")
+                result = await client.get("routing/vrf")
+            return paginate_list(result, limit, offset)
 
         except Exception as e:
             await ctx.error(f"Error listing VRF: {e!s}")

--- a/src/librenms_mcp/tools/oxidized.py
+++ b/src/librenms_mcp/tools/oxidized.py
@@ -9,6 +9,7 @@ from fastmcp.server.context import Context
 from pydantic import Field
 
 from librenms_mcp.librenms_client import LibreNMSClient
+from librenms_mcp.utils import paginate_list
 
 
 def register_oxidized_tools(mcp, config):
@@ -31,12 +32,30 @@ def register_oxidized_tools(mcp, config):
             str | None,
             Field(default=None, description="Filter by device hostname. Optional."),
         ] = None,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         List devices tracked by Oxidized for config backup.
 
         Args:
             hostname (str, optional): Filter by device hostname.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -50,8 +69,8 @@ def register_oxidized_tools(mcp, config):
                 )
                 result = await client.get(path)
                 if isinstance(result, list):
-                    return {"devices": result}
-                return result
+                    result = {"devices": result}
+                return paginate_list(result, limit, offset, key="devices")
 
         except Exception as e:
             await ctx.error(f"Error listing Oxidized devices: {e!s}")
@@ -107,12 +126,30 @@ def register_oxidized_tools(mcp, config):
             ),
         ],
         ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         Search all Oxidized device configurations for a string.
 
         Args:
             search (str): Search string (IP, interface, ACL, keyword, etc.).
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API with matching devices and config snippets.
@@ -125,8 +162,8 @@ def register_oxidized_tools(mcp, config):
                     f"oxidized/config/search/{quote(search, safe='')}"
                 )
                 if isinstance(result, list):
-                    return {"results": result}
-                return result
+                    result = {"results": result}
+                return paginate_list(result, limit, offset, key="results")
 
         except Exception as e:
             await ctx.error(f"Error searching Oxidized configs: {e!s}")

--- a/src/librenms_mcp/tools/ports.py
+++ b/src/librenms_mcp/tools/ports.py
@@ -9,6 +9,7 @@ from fastmcp.server.context import Context
 from pydantic import Field
 
 from librenms_mcp.librenms_client import LibreNMSClient
+from librenms_mcp.utils import paginate_list
 
 
 def register_port_tools(mcp, config):
@@ -34,17 +35,34 @@ def register_port_tools(mcp, config):
                 description="""Query parameters for filtering ports:
 - columns: Comma-separated list of fields to return (e.g., "port_id,ifName,ifAlias")
 - device_id: Filter by device ID
-- limit: Maximum number of results
 
 Available columns: port_id, device_id, ifDescr, ifName, ifAlias, ifType, ifSpeed, ifOperStatus, ifAdminStatus, etc.""",
             ),
         ] = None,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         Get all ports from LibreNMS with optional filters.
 
         Args:
             query (dict, optional): Filter parameters including columns, device_id, and limit.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API containing port list.
@@ -53,7 +71,8 @@ Available columns: port_id, device_id, ifDescr, ifName, ifAlias, ifType, ifSpeed
             await ctx.info("Getting all ports...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get("ports", params=query)
+                result = await client.get("ports", params=query)
+            return paginate_list(result, limit, offset, key="ports")
 
         except Exception as e:
             await ctx.error(f"Error listing ports: {e!s}")
@@ -75,12 +94,30 @@ Available columns: port_id, device_id, ifDescr, ifName, ifAlias, ifType, ifSpeed
             ),
         ],
         ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         Search ports in LibreNMS by search string.
 
         Args:
             search (str): Search term to match against ifAlias, ifDescr, ifName.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -89,7 +126,8 @@ Available columns: port_id, device_id, ifDescr, ifName, ifAlias, ifType, ifSpeed
             await ctx.info(f"Searching ports {search}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(f"ports/search/{quote(search, safe='')}")
+                result = await client.get(f"ports/search/{quote(search, safe='')}")
+            return paginate_list(result, limit, offset, key="ports")
 
         except Exception as e:
             await ctx.error(f"Error searching ports {search}: {e!s}")
@@ -112,6 +150,22 @@ Available columns: port_id, device_id, ifDescr, ifName, ifAlias, ifType, ifSpeed
         ],
         search: Annotated[str, Field(description="Search term")],
         ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         Search ports in LibreNMS by specific field.
@@ -119,6 +173,8 @@ Available columns: port_id, device_id, ifDescr, ifName, ifAlias, ifType, ifSpeed
         Args:
             field (str): Field to search (ifAlias, ifDescr, ifName, etc.).
             search (str): Search term.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -127,9 +183,10 @@ Available columns: port_id, device_id, ifDescr, ifName, ifAlias, ifType, ifSpeed
             await ctx.info(f"Searching ports {field}={search}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(
+                result = await client.get(
                     f"ports/search/{quote(field, safe='')}/{quote(search, safe='')}"
                 )
+            return paginate_list(result, limit, offset, key="ports")
 
         except Exception as e:
             await ctx.error(f"Error field search {field}={search}: {e!s}")
@@ -151,12 +208,30 @@ Available columns: port_id, device_id, ifDescr, ifName, ifAlias, ifType, ifSpeed
             ),
         ],
         ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         Search ports in LibreNMS by MAC address.
 
         Args:
             mac (str): MAC address in any common format.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -165,7 +240,8 @@ Available columns: port_id, device_id, ifDescr, ifName, ifAlias, ifType, ifSpeed
             await ctx.info(f"Searching ports by MAC address {mac}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(f"ports/mac/{quote(mac, safe='')}")
+                result = await client.get(f"ports/mac/{quote(mac, safe='')}")
+            return paginate_list(result, limit, offset, key="ports")
 
         except Exception as e:
             await ctx.error(f"Error MAC search {mac}: {e!s}")
@@ -337,7 +413,25 @@ Available columns: port_id, device_id, ifDescr, ifName, ifAlias, ifType, ifSpeed
             "idempotentHint": True,
         },
     )
-    async def port_groups_list(ctx: Context) -> dict:
+    async def port_groups_list(
+        ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
+    ) -> dict:
         """
         List port groups from LibreNMS.
 
@@ -348,7 +442,8 @@ Available columns: port_id, device_id, ifDescr, ifName, ifAlias, ifType, ifSpeed
             await ctx.info("Getting port groups...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get("port_groups")
+                result = await client.get("port_groups")
+            return paginate_list(result, limit, offset)
 
         except Exception as e:
             await ctx.error(f"Error listing port groups: {e!s}")
@@ -401,13 +496,32 @@ Available columns: port_id, device_id, ifDescr, ifName, ifAlias, ifType, ifSpeed
         },
     )
     async def port_group_list_ports(
-        name: Annotated[str, Field(description="Port group name")], ctx: Context
+        name: Annotated[str, Field(description="Port group name")],
+        ctx: Context,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         List ports in a port group from LibreNMS.
 
         Args:
             name (str): Port group name.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -416,7 +530,8 @@ Available columns: port_id, device_id, ifDescr, ifName, ifAlias, ifType, ifSpeed
             await ctx.info(f"Getting ports in group {name}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(f"port_groups/{quote(name, safe='')}")
+                result = await client.get(f"port_groups/{quote(name, safe='')}")
+            return paginate_list(result, limit, offset)
 
         except Exception as e:
             await ctx.error(f"Error listing ports in group {name}: {e!s}")

--- a/src/librenms_mcp/tools/services.py
+++ b/src/librenms_mcp/tools/services.py
@@ -9,6 +9,7 @@ from fastmcp.server.context import Context
 from pydantic import Field
 
 from librenms_mcp.librenms_client import LibreNMSClient
+from librenms_mcp.utils import paginate_list
 
 
 def register_service_tools(mcp, config):
@@ -39,6 +40,22 @@ def register_service_tools(mcp, config):
                 default=None, description="Filter by service type (SQL LIKE pattern)"
             ),
         ] = None,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         List all services from LibreNMS with optional filters.
@@ -46,6 +63,8 @@ def register_service_tools(mcp, config):
         Args:
             state (int, optional): Filter by state (0=Ok, 1=Warning, 2=Critical).
             service_type (str, optional): Filter by service type.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -60,7 +79,8 @@ def register_service_tools(mcp, config):
             await ctx.info("Listing services...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get("services", params=params if params else None)
+                result = await client.get("services", params=params if params else None)
+            return paginate_list(result, limit, offset, key="services")
 
         except Exception as e:
             await ctx.error(f"Error listing services: {e!s}")
@@ -89,6 +109,22 @@ def register_service_tools(mcp, config):
                 default=None, description="Filter by service type (SQL LIKE pattern)"
             ),
         ] = None,
+        limit: Annotated[
+            int,
+            Field(
+                default=100,
+                description="Maximum number of results to return",
+                ge=1,
+            ),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
     ) -> dict:
         """
         Get services for a device from LibreNMS.
@@ -97,6 +133,8 @@ def register_service_tools(mcp, config):
             hostname (str): Device hostname or ID.
             state (int, optional): Filter by state (0=Ok, 1=Warning, 2=Critical).
             service_type (str, optional): Filter by service type.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
 
         Returns:
             dict: The JSON response from the API.
@@ -111,9 +149,10 @@ def register_service_tools(mcp, config):
             await ctx.info(f"Getting services for {hostname}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(
+                result = await client.get(
                     f"services/{hostname}", params=params if params else None
                 )
+            return paginate_list(result, limit, offset, key="services")
 
         except Exception as e:
             await ctx.error(f"Error services for {hostname}: {e!s}")

--- a/src/librenms_mcp/utils.py
+++ b/src/librenms_mcp/utils.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 TRUTHY_VALUES = ("1", "true", "yes", "on")
 
 
@@ -15,3 +17,62 @@ def parse_bool(val: str | None, default: bool = True) -> bool:
     if val is None:
         return default
     return str(val).strip().casefold() in TRUTHY_VALUES
+
+
+def paginate_list(
+    result: Any,
+    limit: int,
+    offset: int,
+    key: str | None = None,
+) -> Any:
+    """
+    Perform client-side pagination on a list (either directly or inside a dictionary).
+
+    Args:
+        result: The original response from the LibreNMS API.
+        limit (int): The maximum number of results to return.
+        offset (int): The number of results to skip.
+        key (str, optional): The key in the response dictionary containing the list.
+                             If None, it will be auto-detected.
+
+    Returns:
+        The response with the list paginated and metadata added.
+    """
+    if isinstance(result, list):
+        total = len(result)
+        paginated_items = result[offset : offset + limit]
+        return {
+            "items": paginated_items,
+            "count": len(paginated_items),
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+        }
+
+    if not isinstance(result, dict) or result.get("status") == "error":
+        return result
+
+    # Find the target key
+    if key is None:
+        list_keys = [k for k, v in result.items() if isinstance(v, list)]
+        if not list_keys:
+            return result
+        # Sort by list length descending to find the main list
+        list_keys.sort(key=lambda k: len(result[k]), reverse=True)
+        key = list_keys[0]
+
+    items = result.get(key)
+    if not isinstance(items, list):
+        return result
+
+    total = len(items)
+    paginated_items = items[offset : offset + limit]
+
+    paginated_result = {k: v for k, v in result.items() if k != key}
+    paginated_result[key] = paginated_items
+    paginated_result["count"] = len(paginated_items)
+    paginated_result["total"] = total
+    paginated_result["limit"] = limit
+    paginated_result["offset"] = offset
+
+    return paginated_result

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,3 +28,72 @@ from librenms_mcp.utils import parse_bool
 )
 def test_parse_bool(val, default, expected):
     assert parse_bool(val, default) is expected
+
+
+def test_paginate_list_direct_list():
+    from librenms_mcp.utils import paginate_list
+
+    items = [1, 2, 3, 4, 5]
+    result = paginate_list(items, limit=2, offset=1)
+    assert result == {
+        "items": [2, 3],
+        "count": 2,
+        "total": 5,
+        "limit": 2,
+        "offset": 1,
+    }
+
+
+def test_paginate_list_dict_with_key():
+    from librenms_mcp.utils import paginate_list
+
+    data = {
+        "status": "ok",
+        "devices": [{"id": 1}, {"id": 2}, {"id": 3}],
+        "other": "value",
+    }
+    result = paginate_list(data, limit=2, offset=1, key="devices")
+    assert result == {
+        "status": "ok",
+        "devices": [{"id": 2}, {"id": 3}],
+        "other": "value",
+        "count": 2,
+        "total": 3,
+        "limit": 2,
+        "offset": 1,
+    }
+
+
+def test_paginate_list_dict_autodetect():
+    from librenms_mcp.utils import paginate_list
+
+    data = {
+        "status": "ok",
+        "ports": [{"id": 10}, {"id": 20}, {"id": 30}],
+        "some_list": [1],  # shorter list, should prefer the longer one
+    }
+    result = paginate_list(data, limit=1, offset=1)
+    assert result == {
+        "status": "ok",
+        "ports": [{"id": 20}],
+        "some_list": [1],
+        "count": 1,
+        "total": 3,
+        "limit": 1,
+        "offset": 1,
+    }
+
+
+def test_paginate_list_error_and_invalid():
+    from librenms_mcp.utils import paginate_list
+
+    # If it's not dict/list
+    assert paginate_list("not a list", 5, 0) == "not a list"
+
+    # If status is error
+    error_data = {"status": "error", "message": "API error"}
+    assert paginate_list(error_data, 5, 0) == error_data
+
+    # If dictionary has no lists
+    no_lists = {"status": "ok", "value": "some string"}
+    assert paginate_list(no_lists, 5, 0) == no_lists


### PR DESCRIPTION
- Create `paginate_list` client-side pagination utility in `utils.py`
- Add pagination support (defaulting to 100 results per page) to all list/search tools
- Correct default values and start/limit pagination parameters on eventlog, syslog, alertlog, and authlog tools
- Include pagination metadata in tool responses (count, total, limit, offset/start)
- Document pagination behavior in README.md
- Add unit tests for pagination utility