### PR TITLE
fix(types): allow string integers in optional union parameters

### DIFF
--- a/src/librenms_mcp/tools/alerts.py
+++ b/src/librenms_mcp/tools/alerts.py
@@ -29,7 +29,7 @@ def register_alert_tools(mcp, config):
     async def alerts_get(
         ctx: Context,
         state: Annotated[
-            int | None,
+            int | str | None,
             Field(
                 default=None,
                 description="Filter the alerts by state: 0 = ok, 1 = alert, 2 = ack. Optional.",
@@ -43,7 +43,7 @@ def register_alert_tools(mcp, config):
             ),
         ] = None,
         alert_rule: Annotated[
-            int | None,
+            int | str | None,
             Field(
                 default=None, description="Filter alerts by alert rule ID. Optional."
             ),

--- a/src/librenms_mcp/tools/inventory.py
+++ b/src/librenms_mcp/tools/inventory.py
@@ -37,7 +37,7 @@ def register_inventory_tools(mcp, config):
             ),
         ] = None,
         ent_physical_contained_in: Annotated[
-            int | None,
+            int | str | None,
             Field(
                 default=None,
                 description="Filter by parent entity index",

--- a/src/librenms_mcp/tools/network.py
+++ b/src/librenms_mcp/tools/network.py
@@ -93,11 +93,11 @@ def register_network_tools(mcp, config):
             Field(default=None, description="Filter by device hostname"),
         ] = None,
         asn: Annotated[
-            int | None,
+            int | str | None,
             Field(default=None, description="Filter by local ASN"),
         ] = None,
         remote_asn: Annotated[
-            int | None,
+            int | str | None,
             Field(default=None, description="Filter by remote ASN"),
         ] = None,
         remote_address: Annotated[
@@ -123,7 +123,7 @@ def register_network_tools(mcp, config):
             ),
         ] = None,
         bgp_family: Annotated[
-            int | None,
+            int | str | None,
             Field(
                 default=None,
                 description="Filter by address family: 4 (IPv4) or 6 (IPv6)",

--- a/src/librenms_mcp/tools/services.py
+++ b/src/librenms_mcp/tools/services.py
@@ -29,7 +29,7 @@ def register_service_tools(mcp, config):
     async def services_list(
         ctx: Context,
         state: Annotated[
-            int | None,
+            int | str | None,
             Field(
                 default=None, description="Filter by state: 0=Ok, 1=Warning, 2=Critical"
             ),
@@ -98,7 +98,7 @@ def register_service_tools(mcp, config):
         ctx: Context,
         hostname: Annotated[str, Field(description="Device hostname or ID")],
         state: Annotated[
-            int | None,
+            int | str | None,
             Field(
                 default=None, description="Filter by state: 0=Ok, 1=Warning, 2=Critical"
             ),


### PR DESCRIPTION
Change optional `int | None` parameter type hints to `int | str | None` in alerts, network, services, and inventory tools. This prevents input validation schema errors when LLMs pass numbers as strings.