### PR TITLE
chore(docker): optimize Dockerfiles and switch to executable entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,21 @@
 FROM python:3.14-alpine3.24 AS builder
 
-RUN pip install --root-user-action=ignore --no-cache-dir --upgrade pip \
-    && pip install --root-user-action=ignore --no-cache-dir uv
-
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 ENV UV_LINK_MODE=copy
+ENV UV_PYTHON_DOWNLOADS=0
 
 WORKDIR /app
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --all-extras --no-install-project --no-dev
+    uv sync --locked --all-extras --no-install-project --no-dev --no-editable
 
-COPY pyproject.toml uv.lock LICENSE README.md run_server.py ./
+COPY pyproject.toml uv.lock LICENSE README.md ./
 COPY src/ ./src/
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --all-extras --no-dev
+    uv sync --locked --all-extras --no-dev --no-editable
 
 
 FROM python:3.14-alpine3.24
@@ -33,7 +32,7 @@ RUN apk add --no-cache ca-certificates \
     && addgroup -g 1000 appuser \
     && adduser -D -u 1000 -G appuser appuser
 
-COPY --from=builder --chown=appuser:appuser /app /app
+COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
 
 WORKDIR /app
 
@@ -46,7 +45,7 @@ HEALTHCHECK \
   --timeout=5s \
   --start-period=5s \
   --retries=3 \
-  CMD nc -z 127.0.0.1 8000 || exit 1
+  CMD if [ "$MCP_TRANSPORT" = "http" ]; then nc -z 127.0.0.1 "${MCP_HTTP_PORT:-8000}" || exit 1; fi
 
 ENV MCP_TRANSPORT=http
 ENV MCP_HTTP_HOST=0.0.0.0

--- a/Dockerfile.mcpo
+++ b/Dockerfile.mcpo
@@ -1,23 +1,21 @@
 FROM python:3.14-alpine3.24 AS builder
 
-RUN pip install --root-user-action=ignore --no-cache-dir --upgrade pip \
-    && pip install --root-user-action=ignore --no-cache-dir uv
-
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 ENV UV_LINK_MODE=copy
+ENV UV_PYTHON_DOWNLOADS=0
 
 WORKDIR /app
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --all-extras --no-install-project --no-dev \
-    && uv pip install mcpo
+    uv sync --locked --all-extras --no-install-project --no-dev --no-editable
 
-COPY pyproject.toml uv.lock LICENSE README.md run_server.py ./
+COPY pyproject.toml uv.lock LICENSE README.md ./
 COPY src/ ./src/
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --all-extras --no-dev \
+    uv sync --locked --all-extras --no-dev --no-editable \
     && uv pip install mcpo
 
 
@@ -34,7 +32,7 @@ RUN apk add --no-cache ca-certificates \
     && addgroup -g 1000 appuser \
     && adduser -D -u 1000 -G appuser appuser
 
-COPY --from=builder --chown=appuser:appuser /app /app
+COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
 
 WORKDIR /app
 
@@ -51,4 +49,4 @@ HEALTHCHECK \
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "if [ -n \"$MCPO_API_KEY\" ]; then exec mcpo --api-key \"$MCPO_API_KEY\" -- python -u run_server.py; else exec mcpo -- python -u run_server.py; fi"]
+CMD ["sh", "-c", "if [ -n \"$MCPO_API_KEY\" ]; then exec mcpo --api-key \"$MCPO_API_KEY\" -- librenms-mcp; else exec mcpo -- librenms-mcp; fi"]


### PR DESCRIPTION
- Install `uv` by copying from the official `astral-sh/uv` image instead of using `pip`
- Copy only `.venv` to the final stage rather than the entire app directory to reduce image size
- Add `--no-editable` to `uv sync` for a cleaner production installation
- Remove `run_server.py` and update commands to use the `librenms-mcp` CLI executable directly
- Make `Dockerfile` healthcheck conditional to only run when HTTP transport is used
- Remove redundant `mcpo` installation step in `Dockerfile.mcpo`