### PR TITLE
feat: add graph, FDB, port security and NAC tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ MCP_TRANSPORT=stdio
 - `device_delete`: Remove a device
 - `device_ports`: List all ports for a device
 - `device_ports_get`: Get details for a specific port on a device
+- `device_fdb`: List the forwarding database (learned MACs) for a device
+- `device_nac`: List network access control (802.1X / MAB) sessions on a device
 - `device_availability`: Get device availability
 - `device_outages`: Get device outages
 - `device_set_maintenance`: Set device maintenance mode
@@ -245,6 +247,7 @@ MCP_TRANSPORT=stdio
 - `ports_search_field`: Search ports by a specific field
 - `ports_search_mac`: Search ports by MAC address
 - `port_get`: Get details for a specific port
+- `port_fdb`: List MAC addresses learned on a port
 - `port_ip_info`: Get IP address information for a port
 - `port_transceiver`: Get transceiver information for a port
 - `port_description_get`: Get a port description
@@ -254,6 +257,26 @@ MCP_TRANSPORT=stdio
 - `port_group_list_ports`: List ports in a port group
 - `port_group_assign`: Assign ports to a port group
 - `port_group_remove`: Remove ports from a port group
+
+### Port Security Tools
+
+- `port_security_list`: List port security configuration across all devices
+- `port_security_device`: Get port security configuration for a device
+- `port_security_port`: Get port security configuration for a single port
+
+### Graph Tools
+
+Graphs are returned as MCP images. LibreNMS serves SVG on current releases and
+PNG on older ones; the MIME type is taken from the response.
+
+- `device_graphs_list`: List the graph types available for a device
+- `device_graph`: Render a device-level graph (e.g. `device_icmp_perf`)
+- `port_graph`: Render a per-port graph by interface name (`bits`, `upkts`, `errors`, `etherlike`)
+- `port_group_graph`: Render a traffic graph for one or more ports by port ID
+
+`port_graph` falls back to the port-group endpoint for `bits` when the per-port
+endpoint fails, which works around LibreNMS releases that return a 500 naming an
+empty graph type.
 
 ### Alerting & Logging Tools
 
@@ -309,6 +332,7 @@ MCP_TRANSPORT=stdio
 - `bgp_session_get`: Get details for a specific BGP session
 - `bgp_session_edit`: Edit a BGP session
 - `fdb_lookup`: Lookup forwarding database (FDB) entries
+- `nac_list`: List network access control (802.1X / MAB) sessions across all devices
 - `ospf_list`: List OSPF instances
 - `ospf_ports`: List OSPF ports
 - `vrf_list`: List VRFs

--- a/src/librenms_mcp/librenms_client.py
+++ b/src/librenms_mcp/librenms_client.py
@@ -83,6 +83,31 @@ class LibreNMSClient:
         """Perform a GET request to a LibreNMS API path."""
         return await self.request("GET", path, params=params)
 
+    async def get_raw(
+        self, path: str, params: dict[str, Any] | None = None
+    ) -> tuple[bytes, str]:
+        """Perform a GET request returning the undecoded body and its content type.
+
+        Graph endpoints return an image (SVG or PNG depending on the LibreNMS
+        version and rrdtool build) rather than JSON, so they cannot go through
+        `get()`, which would fail to decode the body.
+
+        Args:
+            path: LibreNMS API path.
+            params: Optional query parameters.
+
+        Returns:
+            tuple[bytes, str]: The raw response body and its MIME type.
+        """
+        if self.client is None:
+            raise RuntimeError(
+                "Client not initialized - use 'async with LibreNMSClient(config)' or call __aenter__"
+            )
+        resp = await self.client.get(path.lstrip("/"), params=params)
+        resp.raise_for_status()
+        content_type = resp.headers.get("content-type", "application/octet-stream")
+        return resp.content, content_type.split(";")[0].strip()
+
     async def post(
         self, path: str, data: dict[str, Any] | None = None
     ) -> dict[str, Any]:

--- a/src/librenms_mcp/tools/__init__.py
+++ b/src/librenms_mcp/tools/__init__.py
@@ -3,6 +3,7 @@
 from librenms_mcp.tools.alerts import register_alert_tools
 from librenms_mcp.tools.bills import register_bill_tools
 from librenms_mcp.tools.devices import register_device_tools
+from librenms_mcp.tools.graphs import register_graph_tools
 from librenms_mcp.tools.health import register_health_tools
 from librenms_mcp.tools.inventory import register_inventory_tools
 from librenms_mcp.tools.locations import register_location_tools
@@ -10,6 +11,7 @@ from librenms_mcp.tools.logs import register_logs_tools
 from librenms_mcp.tools.network import register_network_tools
 from librenms_mcp.tools.oxidized import register_oxidized_tools
 from librenms_mcp.tools.pollers import register_poller_tools
+from librenms_mcp.tools.port_security import register_port_security_tools
 from librenms_mcp.tools.ports import register_port_tools
 from librenms_mcp.tools.services import register_service_tools
 from librenms_mcp.tools.system import register_system_tools
@@ -20,6 +22,7 @@ def register_tools(mcp, config):
     register_alert_tools(mcp, config)
     register_bill_tools(mcp, config)
     register_device_tools(mcp, config)
+    register_graph_tools(mcp, config)
     register_health_tools(mcp, config)
     register_inventory_tools(mcp, config)
     register_location_tools(mcp, config)
@@ -27,6 +30,7 @@ def register_tools(mcp, config):
     register_network_tools(mcp, config)
     register_oxidized_tools(mcp, config)
     register_poller_tools(mcp, config)
+    register_port_security_tools(mcp, config)
     register_port_tools(mcp, config)
     register_service_tools(mcp, config)
     register_system_tools(mcp, config)

--- a/src/librenms_mcp/tools/devices.py
+++ b/src/librenms_mcp/tools/devices.py
@@ -1076,3 +1076,101 @@ Example dynamic group:
         except Exception as e:
             await ctx.error(f"Error adding event log for {hostname}: {e!s}")
             return {"error": str(e)}
+
+    @mcp.tool(
+        tags={"librenms", "devices", "fdb", "read-only"},
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        },
+    )
+    async def device_fdb(
+        hostname: Annotated[str, Field(description="Device hostname or device ID")],
+        ctx: Context,
+        limit: Annotated[
+            int,
+            Field(default=100, description="Maximum number of results to return", ge=1),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
+    ) -> dict:
+        """
+        List the forwarding database (learned MAC addresses) for a device.
+
+        Each entry carries the port_id it was learned on, so this is the
+        device-wide view of what is plugged into a switch.
+
+        Args:
+            hostname (str): Device hostname or device ID.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
+
+        Returns:
+            dict: The JSON response from the API.
+        """
+        try:
+            await ctx.info(f"Listing FDB entries for {hostname}...")
+
+            async with LibreNMSClient(config) as client:
+                result = await client.get(f"devices/{quote(hostname, safe='')}/fdb")
+                return paginate_list(result, limit, offset, key="ports_fdb")
+
+        except Exception as e:
+            await ctx.error(f"Error listing FDB for {hostname}: {e!s}")
+            return {"error": str(e)}
+
+    @mcp.tool(
+        tags={"librenms", "devices", "nac", "read-only"},
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        },
+    )
+    async def device_nac(
+        hostname: Annotated[str, Field(description="Device hostname or device ID")],
+        ctx: Context,
+        limit: Annotated[
+            int,
+            Field(default=100, description="Maximum number of results to return", ge=1),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
+    ) -> dict:
+        """
+        List network access control (802.1X / MAB) sessions on a device.
+
+        Shows authenticated endpoints per port, including the authentication
+        method and the assigned VLAN where the device reports it.
+
+        Args:
+            hostname (str): Device hostname or device ID.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
+
+        Returns:
+            dict: The JSON response from the API.
+        """
+        try:
+            await ctx.info(f"Listing NAC sessions for {hostname}...")
+
+            async with LibreNMSClient(config) as client:
+                result = await client.get(f"devices/{quote(hostname, safe='')}/nac")
+                return paginate_list(result, limit, offset, key="ports_nac")
+
+        except Exception as e:
+            await ctx.error(f"Error listing NAC sessions for {hostname}: {e!s}")
+            return {"error": str(e)}

--- a/src/librenms_mcp/tools/graphs.py
+++ b/src/librenms_mcp/tools/graphs.py
@@ -1,0 +1,333 @@
+"""
+LibreNMS MCP Server Graph Tools
+"""
+
+from typing import Annotated
+from typing import Any
+from urllib.parse import quote
+
+from fastmcp.exceptions import ToolError
+from fastmcp.server.context import Context
+from fastmcp.utilities.types import Image
+from pydantic import Field
+
+from librenms_mcp.librenms_client import LibreNMSClient
+
+# Graph endpoints return an image, so a failure cannot be reported as a dict the
+# way the JSON tools do. They raise ToolError instead.
+
+FromField = Annotated[
+    str | None,
+    Field(
+        default=None,
+        description="Start of the time range, either a relative offset such as '-1d', '-6h' or '-1w', or a Unix timestamp. Defaults to the LibreNMS default (-1d).",
+    ),
+]
+ToField = Annotated[
+    str | None,
+    Field(
+        default=None,
+        description="End of the time range, either a relative offset or a Unix timestamp. Defaults to now.",
+    ),
+]
+WidthField = Annotated[
+    int | None,
+    Field(default=None, description="Graph width in pixels.", ge=1),
+]
+HeightField = Annotated[
+    int | None,
+    Field(default=None, description="Graph height in pixels.", ge=1),
+]
+LegendField = Annotated[
+    bool | None,
+    Field(default=None, description="Whether to render the graph legend."),
+]
+
+
+def _graph_params(
+    from_: str | None,
+    to: str | None,
+    width: int | None,
+    height: int | None,
+    legend: bool | None,
+) -> dict[str, Any]:
+    """Build the query parameters shared by every graph endpoint."""
+    params: dict[str, Any] = {}
+    if from_ is not None:
+        params["from"] = from_
+    if to is not None:
+        params["to"] = to
+    if width is not None:
+        params["width"] = width
+    if height is not None:
+        params["height"] = height
+    if legend is not None:
+        params["legend"] = "yes" if legend else "no"
+    return params
+
+
+async def _resolve_port_id(client: LibreNMSClient, hostname: str, ifname: str) -> int:
+    """Look up the numeric port ID behind a device hostname and interface name."""
+    result = await client.get(
+        f"devices/{quote(hostname, safe='')}/ports",
+        params={"columns": "port_id,ifName"},
+    )
+    for port in result.get("ports") or []:
+        if str(port.get("ifName", "")).casefold() == ifname.casefold():
+            return int(port["port_id"])
+    raise ToolError(f"No interface named '{ifname}' found on {hostname}.")
+
+
+def _to_image(data: bytes, content_type: str) -> Image:
+    """Wrap a graph response body in an MCP image.
+
+    LibreNMS serves graphs as SVG on current releases and as PNG on older ones,
+    so the MIME type is taken from the response rather than assumed.
+    """
+    if not content_type.startswith("image/"):
+        raise ToolError(
+            f"Expected an image from the LibreNMS graph endpoint, got '{content_type}'. "
+            "This usually means LibreNMS returned a JSON error instead of rendering the graph."
+        )
+    return Image(data=data, format=content_type.removeprefix("image/"))
+
+
+def register_graph_tools(mcp, config):
+    """Register LibreNMS graph tools with the MCP server"""
+    ##########################
+    # Graph Tools
+    ##########################
+
+    @mcp.tool(
+        tags={"librenms", "graphs", "read-only"},
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        },
+    )
+    async def device_graphs_list(
+        hostname: Annotated[str, Field(description="Device hostname or device ID")],
+        ctx: Context,
+    ) -> dict:
+        """
+        List the graph types available for a device.
+
+        Use this to discover the values accepted by the `graph_type` argument of
+        device_graph, for example 'device_icmp_perf' or 'device_poller_perf'.
+
+        Args:
+            hostname (str): Device hostname or device ID.
+
+        Returns:
+            dict: The JSON response from the API listing available graphs.
+        """
+        try:
+            await ctx.info(f"Listing available graphs for {hostname}...")
+
+            async with LibreNMSClient(config) as client:
+                return await client.get(f"devices/{quote(hostname, safe='')}/graphs")
+
+        except Exception as e:
+            await ctx.error(f"Error listing graphs for {hostname}: {e!s}")
+            return {"error": str(e)}
+
+    @mcp.tool(
+        tags={"librenms", "graphs", "read-only"},
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        },
+    )
+    async def device_graph(
+        hostname: Annotated[str, Field(description="Device hostname or device ID")],
+        graph_type: Annotated[
+            str,
+            Field(
+                description="Graph type, as returned by device_graphs_list (e.g. 'device_icmp_perf', 'device_poller_perf', 'device_availability')"
+            ),
+        ],
+        ctx: Context,
+        from_time: FromField = None,
+        to_time: ToField = None,
+        width: WidthField = None,
+        height: HeightField = None,
+        legend: LegendField = None,
+    ) -> Image:
+        """
+        Render a device-level graph as an image.
+
+        Args:
+            hostname (str): Device hostname or device ID.
+            graph_type (str): Graph type from device_graphs_list.
+            from_time (str, optional): Start of the time range, e.g. '-1d'.
+            to_time (str, optional): End of the time range.
+            width (int, optional): Graph width in pixels.
+            height (int, optional): Graph height in pixels.
+            legend (bool, optional): Whether to render the legend.
+
+        Returns:
+            Image: The rendered graph.
+        """
+        try:
+            await ctx.info(f"Rendering {graph_type} graph for {hostname}...")
+
+            async with LibreNMSClient(config) as client:
+                data, content_type = await client.get_raw(
+                    f"devices/{quote(hostname, safe='')}/{quote(graph_type, safe='')}",
+                    params=_graph_params(from_time, to_time, width, height, legend),
+                )
+                return _to_image(data, content_type)
+
+        except ToolError:
+            raise
+        except Exception as e:
+            await ctx.error(f"Error rendering {graph_type} graph for {hostname}: {e!s}")
+            raise ToolError(
+                f"Could not render the {graph_type} graph for {hostname}: {e!s}"
+            ) from e
+
+    @mcp.tool(
+        tags={"librenms", "graphs", "ports", "read-only"},
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        },
+    )
+    async def port_graph(
+        hostname: Annotated[str, Field(description="Device hostname or device ID")],
+        ifname: Annotated[
+            str,
+            Field(
+                description="Interface name as reported by LibreNMS, e.g. 'Po1' or 'Te2/7'"
+            ),
+        ],
+        ctx: Context,
+        graph_type: Annotated[
+            str,
+            Field(
+                default="bits",
+                description="Graph type: 'bits' (traffic), 'upkts' (unicast packets), 'errors', or 'etherlike'",
+            ),
+        ] = "bits",
+        from_time: FromField = None,
+        to_time: ToField = None,
+        width: WidthField = None,
+        height: HeightField = None,
+        legend: LegendField = None,
+    ) -> Image:
+        """
+        Render a per-port graph as an image, for example interface traffic.
+
+        Some LibreNMS releases fail to render through the per-port endpoint and
+        answer 500 with an empty graph type in the message. For 'bits' this tool
+        then falls back to the port-group endpoint, which renders the same
+        traffic data, so callers still get a graph without needing a port ID.
+
+        Args:
+            hostname (str): Device hostname or device ID.
+            ifname (str): Interface name, e.g. 'Po1' or 'Te2/7'.
+            graph_type (str): bits, upkts, errors or etherlike.
+            from_time (str, optional): Start of the time range, e.g. '-1d'.
+            to_time (str, optional): End of the time range.
+            width (int, optional): Graph width in pixels.
+            height (int, optional): Graph height in pixels.
+            legend (bool, optional): Whether to render the legend.
+
+        Returns:
+            Image: The rendered graph.
+        """
+        params = _graph_params(from_time, to_time, width, height, legend)
+        try:
+            await ctx.info(f"Rendering {graph_type} graph for {hostname} {ifname}...")
+
+            async with LibreNMSClient(config) as client:
+                try:
+                    data, content_type = await client.get_raw(
+                        f"devices/{quote(hostname, safe='')}/ports/{quote(ifname, safe='')}/{quote(graph_type, safe='')}",
+                        params=params,
+                    )
+                except Exception as e:
+                    # Only 'bits' has a port-group equivalent to fall back to.
+                    if graph_type != "bits":
+                        raise
+                    await ctx.info(
+                        f"Per-port graph endpoint failed ({e!s}); retrying via the port-group endpoint..."
+                    )
+                    port_id = await _resolve_port_id(client, hostname, ifname)
+                    data, content_type = await client.get_raw(
+                        f"portgroups/multiport/bits/{port_id}", params=params
+                    )
+                return _to_image(data, content_type)
+
+        except ToolError:
+            raise
+        except Exception as e:
+            await ctx.error(
+                f"Error rendering {graph_type} graph for {hostname} {ifname}: {e!s}"
+            )
+            raise ToolError(
+                f"Could not render the {graph_type} graph for {hostname} {ifname}: {e!s}"
+            ) from e
+
+    @mcp.tool(
+        tags={"librenms", "graphs", "ports", "read-only"},
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        },
+    )
+    async def port_group_graph(
+        port_ids: Annotated[
+            list[int],
+            Field(
+                description="One or more port IDs to plot on a single graph. Resolve names to IDs with ports_search_field or device_ports.",
+                min_length=1,
+            ),
+        ],
+        ctx: Context,
+        from_time: FromField = None,
+        to_time: ToField = None,
+        width: WidthField = None,
+        height: HeightField = None,
+        legend: LegendField = None,
+    ) -> Image:
+        """
+        Render a traffic graph for one or more ports, by port ID.
+
+        Plots every supplied port on the same axes, which makes it useful for
+        comparing members of a LAG. Unlike port_graph this takes numeric port
+        IDs rather than interface names.
+
+        Args:
+            port_ids (list[int]): Port IDs to plot.
+            from_time (str, optional): Start of the time range, e.g. '-1d'.
+            to_time (str, optional): End of the time range.
+            width (int, optional): Graph width in pixels.
+            height (int, optional): Graph height in pixels.
+            legend (bool, optional): Whether to render the legend.
+
+        Returns:
+            Image: The rendered graph.
+        """
+        ids = ",".join(str(port_id) for port_id in port_ids)
+        try:
+            await ctx.info(f"Rendering traffic graph for port(s) {ids}...")
+
+            async with LibreNMSClient(config) as client:
+                data, content_type = await client.get_raw(
+                    f"portgroups/multiport/bits/{quote(ids, safe='')}",
+                    params=_graph_params(from_time, to_time, width, height, legend),
+                )
+                return _to_image(data, content_type)
+
+        except ToolError:
+            raise
+        except Exception as e:
+            await ctx.error(f"Error rendering traffic graph for port(s) {ids}: {e!s}")
+            raise ToolError(
+                f"Could not render the traffic graph for port(s) {ids}: {e!s}"
+            ) from e

--- a/src/librenms_mcp/tools/network.py
+++ b/src/librenms_mcp/tools/network.py
@@ -566,3 +566,61 @@ def register_network_tools(mcp, config):
         except Exception as e:
             await ctx.error(f"Error listing VRF: {e!s}")
             return {"error": str(e)}
+
+    @mcp.tool(
+        tags={"librenms", "network", "nac", "read-only"},
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        },
+    )
+    async def nac_list(
+        ctx: Context,
+        mac: Annotated[
+            str | None,
+            Field(
+                default=None,
+                description="Filter to a single MAC address. Optional.",
+            ),
+        ] = None,
+        limit: Annotated[
+            int,
+            Field(default=100, description="Maximum number of results to return", ge=1),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
+    ) -> dict:
+        """
+        List network access control (802.1X / MAB) sessions across all devices.
+
+        Note that LibreNMS answers with a 404 and "Nac entry does not exist"
+        rather than an empty list when nothing matches.
+
+        Args:
+            mac (str, optional): Restrict the result to a single MAC address.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
+
+        Returns:
+            dict: The JSON response from the API.
+        """
+        try:
+            await ctx.info("Listing NAC sessions...")
+
+            async with LibreNMSClient(config) as client:
+                path = (
+                    f"resources/nac/{quote(mac, safe='')}" if mac else "resources/nac"
+                )
+                result = await client.get(path)
+            return paginate_list(result, limit, offset)
+
+        except Exception as e:
+            await ctx.error(f"Error listing NAC sessions: {e!s}")
+            return {"error": str(e)}

--- a/src/librenms_mcp/tools/port_security.py
+++ b/src/librenms_mcp/tools/port_security.py
@@ -1,0 +1,145 @@
+"""
+LibreNMS MCP Server Port Security Tools
+"""
+
+from typing import Annotated
+from urllib.parse import quote
+
+from fastmcp.server.context import Context
+from pydantic import Field
+
+from librenms_mcp.librenms_client import LibreNMSClient
+from librenms_mcp.utils import paginate_list
+
+
+def register_port_security_tools(mcp, config):
+    """Register LibreNMS port security tools with the MCP server"""
+    ##########################
+    # Port Security Tools
+    ##########################
+
+    @mcp.tool(
+        tags={"librenms", "ports", "port-security", "read-only"},
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        },
+    )
+    async def port_security_list(
+        ctx: Context,
+        limit: Annotated[
+            int,
+            Field(default=100, description="Maximum number of results to return", ge=1),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
+    ) -> dict:
+        """
+        List port security configuration across all devices.
+
+        Covers switchport port-security state such as the maximum number of
+        learned MAC addresses, violation mode and current status.
+
+        Args:
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
+
+        Returns:
+            dict: The JSON response from the API.
+        """
+        try:
+            await ctx.info("Listing port security configuration...")
+
+            async with LibreNMSClient(config) as client:
+                result = await client.get("port_security")
+                return paginate_list(result, limit, offset, key="port")
+
+        except Exception as e:
+            await ctx.error(f"Error listing port security configuration: {e!s}")
+            return {"error": str(e)}
+
+    @mcp.tool(
+        tags={"librenms", "ports", "port-security", "read-only"},
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        },
+    )
+    async def port_security_device(
+        hostname: Annotated[str, Field(description="Device hostname or device ID")],
+        ctx: Context,
+        limit: Annotated[
+            int,
+            Field(default=100, description="Maximum number of results to return", ge=1),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
+    ) -> dict:
+        """
+        Get port security configuration for every port on a device.
+
+        Args:
+            hostname (str): Device hostname or device ID.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
+
+        Returns:
+            dict: The JSON response from the API.
+        """
+        try:
+            await ctx.info(f"Getting port security for {hostname}...")
+
+            async with LibreNMSClient(config) as client:
+                result = await client.get(
+                    f"port_security/device/{quote(hostname, safe='')}"
+                )
+                return paginate_list(result, limit, offset, key="port")
+
+        except Exception as e:
+            await ctx.error(f"Error getting port security for {hostname}: {e!s}")
+            return {"error": str(e)}
+
+    @mcp.tool(
+        tags={"librenms", "ports", "port-security", "read-only"},
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        },
+    )
+    async def port_security_port(
+        port_id: Annotated[int, Field(ge=1, description="Port ID")],
+        ctx: Context,
+    ) -> dict:
+        """
+        Get port security configuration for a single port.
+
+        Args:
+            port_id (int): Port ID.
+
+        Returns:
+            dict: The JSON response from the API.
+        """
+        try:
+            await ctx.info(f"Getting port security for port {port_id}...")
+
+            async with LibreNMSClient(config) as client:
+                return await client.get(f"port_security/port/{port_id}")
+
+        except Exception as e:
+            await ctx.error(f"Error getting port security for port {port_id}: {e!s}")
+            return {"error": str(e)}

--- a/src/librenms_mcp/tools/ports.py
+++ b/src/librenms_mcp/tools/ports.py
@@ -612,3 +612,52 @@ Available columns: port_id, device_id, ifDescr, ifName, ifAlias, ifType, ifSpeed
         except Exception as e:
             await ctx.error(f"Error removing port group {port_group_id}: {e!s}")
             return {"error": str(e)}
+
+    @mcp.tool(
+        tags={"librenms", "ports", "fdb", "read-only"},
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        },
+    )
+    async def port_fdb(
+        port_id: Annotated[int, Field(ge=1, description="Port ID")],
+        ctx: Context,
+        limit: Annotated[
+            int,
+            Field(default=100, description="Maximum number of results to return", ge=1),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(
+                default=0,
+                description="Number of results to skip (offset) for pagination",
+                ge=0,
+            ),
+        ] = 0,
+    ) -> dict:
+        """
+        List the MAC addresses learned on a port, from the forwarding database.
+
+        This answers "what is connected to this port". To go the other way and
+        find which port a known MAC sits on, use fdb_lookup instead.
+
+        Args:
+            port_id (int): Port ID.
+            limit (int): Maximum number of results to return.
+            offset (int): Number of results to skip.
+
+        Returns:
+            dict: The JSON response from the API.
+        """
+        try:
+            await ctx.info(f"Listing FDB entries for port {port_id}...")
+
+            async with LibreNMSClient(config) as client:
+                result = await client.get(f"ports/{port_id}/fdb")
+                return paginate_list(result, limit, offset, key="macs")
+
+        except Exception as e:
+            await ctx.error(f"Error listing FDB for port {port_id}: {e!s}")
+            return {"error": str(e)}

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -1,0 +1,113 @@
+from typing import cast
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from librenms_mcp.librenms_client import LibreNMSClient
+from librenms_mcp.tools.graphs import _graph_params
+from librenms_mcp.tools.graphs import _resolve_port_id
+from librenms_mcp.tools.graphs import _to_image
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        (
+            {"from_": None, "to": None, "width": None, "height": None, "legend": None},
+            {},
+        ),
+        (
+            {"from_": "-1d", "to": None, "width": None, "height": None, "legend": None},
+            {"from": "-1d"},
+        ),
+        (
+            {
+                "from_": "-1d",
+                "to": "-1h",
+                "width": 900,
+                "height": 300,
+                "legend": True,
+            },
+            {
+                "from": "-1d",
+                "to": "-1h",
+                "width": 900,
+                "height": 300,
+                "legend": "yes",
+            },
+        ),
+        (
+            {
+                "from_": None,
+                "to": None,
+                "width": None,
+                "height": None,
+                "legend": False,
+            },
+            {"legend": "no"},
+        ),
+    ],
+)
+def test_graph_params_omits_unset_values(kwargs, expected):
+    assert _graph_params(**kwargs) == expected
+
+
+@pytest.mark.parametrize(
+    ("content_type", "expected_mime"),
+    [
+        ("image/svg+xml", "image/svg+xml"),
+        ("image/png", "image/png"),
+    ],
+)
+def test_to_image_preserves_content_type(content_type, expected_mime):
+    image = _to_image(b"payload", content_type)
+    assert image.to_image_content().mimeType == expected_mime
+
+
+def test_to_image_rejects_non_image():
+    # LibreNMS answers graph failures with a JSON body rather than an image.
+    with pytest.raises(ToolError, match="application/json"):
+        _to_image(b'{"status": "error"}', "application/json")
+
+
+class _FakeClient:
+    """Minimal stand-in exposing only the get() used by _resolve_port_id.
+
+    Instantiating a real LibreNMSClient is not viable here: it is a singleton, so
+    building one in a test would leak into every later test in the session.
+    Callers cast it to LibreNMSClient, since only get() is exercised.
+    """
+
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+        self.calls: list[tuple[str, dict | None]] = []
+
+    async def get(self, path: str, params: dict | None = None) -> dict:
+        self.calls.append((path, params))
+        return self._payload
+
+
+def _as_client(fake: _FakeClient) -> LibreNMSClient:
+    """Present the test double as the client type the helper expects."""
+    return cast(LibreNMSClient, fake)
+
+
+@pytest.mark.asyncio
+async def test_resolve_port_id_matches_case_insensitively():
+    client = _FakeClient({"ports": [{"port_id": 7, "ifName": "Te2/7"}]})
+    assert await _resolve_port_id(_as_client(client), "sw1", "te2/7") == 7
+    assert client.calls == [("devices/sw1/ports", {"columns": "port_id,ifName"})]
+
+
+@pytest.mark.asyncio
+async def test_resolve_port_id_encodes_hostname():
+    client = _FakeClient({"ports": [{"port_id": 1, "ifName": "Po1"}]})
+    await _resolve_port_id(_as_client(client), "sw 1/a", "Po1")
+    assert client.calls[0][0] == "devices/sw%201%2Fa/ports"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("payload", [{"ports": []}, {"ports": None}, {}])
+async def test_resolve_port_id_raises_when_absent(payload):
+    with pytest.raises(ToolError, match="No interface named"):
+        await _resolve_port_id(_as_client(_FakeClient(payload)), "sw1", "Po1")


### PR DESCRIPTION
Adds tools for a set of LibreNMS API endpoints that currently have no coverage.

## Graphs

New `graphs.py` module: `device_graphs_list`, `device_graph`, `port_graph`, `port_group_graph`.

Graph endpoints return an image rather than JSON, so they cannot go through `client.get()`, which decodes the body as JSON. `LibreNMSClient` gains `get_raw()`, returning the undecoded body alongside its content type. The MIME type is taken from the response rather than assumed, because LibreNMS serves SVG on current releases and PNG on older ones.

Graphs are returned as MCP images via `fastmcp.utilities.types.Image`. Since a failure cannot be reported as the `{"error": ...}` dict the JSON tools use, these four raise `ToolError` instead.

One workaround worth flagging: on some LibreNMS releases the per-port graph endpoint fails with

```
500 Failed opening required '/opt/librenms/includes/html/graphs//auth.inc.php'
```

The doubled slash is an empty graph type resolved server-side; it reproduces for every port and every `graph_type`. For `bits`, `port_graph` resolves the interface name to a port ID and retries via `portgroups/multiport/bits/{id}`, which renders the same data, so callers still get a graph without needing to know port IDs. Happy to drop the fallback if you would rather not carry a workaround for a LibreNMS-side bug.

## Forwarding database

`device_fdb` (`devices/{hostname}/fdb`) and `port_fdb` (`ports/{portid}/fdb`).

`fdb_lookup` already searches *by* MAC. These answer the opposite question — which MACs are on a given device or port — which is the more common switch-troubleshooting direction.

## Port security

New `port_security.py` module: `port_security_list`, `port_security_device`, `port_security_port`. The `port_security` namespace was previously unexposed.

## Network access control

`device_nac` (`devices/{hostname}/nac`) and `nac_list` (`resources/nac`, `resources/nac/{mac}`).

Note that LibreNMS answers `resources/nac` with a 404 and `Nac entry does not exist` rather than an empty list when nothing matches; this is documented in the tool docstring.

## Notes

- All new tools are tagged `read-only` with matching annotations, so they stay available under `READ_ONLY_MODE`.
- Existing conventions followed: `Annotated`/`Field` arguments, `ctx.info`/`ctx.error`, `paginate_list` with an explicit response key, `quote(..., safe="")` on path parameters.
- README updated.
- Adds `tests/test_graphs.py` covering parameter building, MIME passthrough, the non-image guard, and port-ID resolution including case-insensitive matching and hostname encoding. Full suite: 34 passed. `ruff check` and `ruff format` clean.
- Verified against a live LibreNMS 24.x instance: all 11 new tools exercised, including images returned as `image/svg+xml`.