### PR TITLE
fix(tools): stop tagging read-only tools as admin

### DIFF
--- a/src/librenms_mcp/tools/locations.py
+++ b/src/librenms_mcp/tools/locations.py
@@ -180,14 +180,17 @@ def register_location_tools(mcp, config):
             return {"error": str(e)}
 
     @mcp.tool(
-        tags={"librenms", "locations", "read-only", "admin"},
+        tags={"librenms", "locations", "read-only", "global-read"},
         annotations={
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
         },
     )
-    async def location_get(location: Annotated[str, Field()], ctx: Context) -> dict:
+    async def location_get(
+        location: Annotated[str, Field(description="Location identifier or name")],
+        ctx: Context,
+    ) -> dict:
         """
         Get a specific location from LibreNMS by identifier.
 

--- a/src/librenms_mcp/tools/logs.py
+++ b/src/librenms_mcp/tools/logs.py
@@ -330,10 +330,11 @@ def register_logs_tools(mcp, config):
         ] = None,
     ) -> dict:
         """
-        Get auth logs for a device from LibreNMS.
+        Get authentication logs from LibreNMS.
+
+        Auth logs are server-wide rather than per-device, so this takes no hostname.
 
         Args:
-            hostname (str): Device hostname or ID.
             start (int): Number of results to skip.
             limit (int): Max results.
             from_ts (str, optional): Start timestamp.

--- a/src/librenms_mcp/tools/pollers.py
+++ b/src/librenms_mcp/tools/pollers.py
@@ -17,7 +17,7 @@ def register_poller_tools(mcp, config):
     ##########################
 
     @mcp.tool(
-        tags={"librenms", "poller-groups", "read-only", "admin"},
+        tags={"librenms", "poller-groups", "read-only", "global-read"},
         annotations={
             "readOnlyHint": True,
             "destructiveHint": False,


### PR DESCRIPTION
location_get and poller_group_get were tagged both "read-only" and "admin" despite only reading. Tags drive visibility, so disabling write tools with DISABLED_TAGS=admin - the obvious way to do it - silently took these two reads with it. Both are tagged "global-read" alongside their peers now.

Add a sweep over every tool module asserting that no read-only tool carries "admin" and that the read-only tag agrees with the readOnlyHint annotation.

Also fix the logs_authlog docstring, which documented a hostname argument the tool does not take: auth logs are server-wide.