### PR TITLE
fix(client): report the status code for non-JSON responses

### DIFF
--- a/src/librenms_mcp/librenms_client.py
+++ b/src/librenms_mcp/librenms_client.py
@@ -13,7 +13,12 @@ logger = logging.getLogger(__name__)
 
 
 class LibreNMSClient:
-    """Async client for LibreNMS API using API token authentication"""
+    """Async client for LibreNMS API using API token authentication.
+
+    This is a singleton so that every tool shares one connection pool. Only the
+    first call's config is used - a config passed to a later call is discarded,
+    which is safe here because the server builds exactly one config at startup.
+    """
 
     _instance = None
     _initialized = False
@@ -67,15 +72,29 @@ class LibreNMSClient:
         params: dict[str, Any] | None = None,
         data: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Perform a request to a LibreNMS API path."""
+        """Perform a request to a LibreNMS API path.
+
+        The status code is deliberately not raised on: LibreNMS reports its own
+        errors as JSON (``{"status": "error", "message": ...}``) alongside 4xx/5xx
+        codes, and that message is more useful to the caller than the code. A body
+        that is not JSON at all is not from LibreNMS - a reverse proxy error page,
+        for instance - so that is surfaced with the status code attached rather
+        than as a bare "Expecting value" decode error.
+        """
         if self.client is None:
             raise RuntimeError(
                 "Client not initialized - use 'async with LibreNMSClient(config)' or call __aenter__"
             )
         url = path.lstrip("/")
         resp = await self.client.request(method, url, params=params, json=data)
-        # resp.raise_for_status()
-        return resp.json()
+        try:
+            return resp.json()
+        except ValueError as e:
+            snippet = resp.text.strip()[:200] or "<empty body>"
+            raise RuntimeError(
+                f"LibreNMS returned a non-JSON response for {method} {url} "
+                f"(HTTP {resp.status_code}): {snippet}"
+            ) from e
 
     async def get(
         self, path: str, params: dict[str, Any] | None = None
@@ -189,18 +208,3 @@ def get_transport_config_from_env() -> TransportConfig:
         http_port=int(os.getenv("MCP_HTTP_PORT", "8000")),
         http_bearer_token=http_bearer_token,
     )
-
-
-_librenms_client_singleton: LibreNMSClient | None = None
-
-
-def get_librenms_client(config: LibreNMSConfig | None = None) -> LibreNMSClient:
-    """Get the singleton LibreNMS client instance."""
-    global _librenms_client_singleton
-    if _librenms_client_singleton is None:
-        if config is None:
-            raise ValueError(
-                "LibreNMS config must be provided for first initialization"
-            )
-        _librenms_client_singleton = LibreNMSClient(config)
-    return _librenms_client_singleton

--- a/tests/test_client_errors.py
+++ b/tests/test_client_errors.py
@@ -1,0 +1,63 @@
+"""Guards for how the client reports responses it cannot decode."""
+
+import httpx
+import pytest
+
+from librenms_mcp.librenms_client import LibreNMSClient
+from librenms_mcp.models import LibreNMSConfig
+
+
+@pytest.fixture
+def mock_client():
+    """Yield a client whose transport is scripted per test.
+
+    LibreNMSClient is a singleton, so the class state is reset around each test
+    rather than leaking an instance into the others.
+    """
+
+    def build(handler) -> LibreNMSClient:
+        client = LibreNMSClient(
+            LibreNMSConfig(librenms_url="https://nms.invalid", token="t")
+        )
+        client.client = httpx.AsyncClient(
+            base_url=client.base_url, transport=httpx.MockTransport(handler)
+        )
+        return client
+
+    LibreNMSClient._instance = None
+    LibreNMSClient._initialized = False
+    try:
+        yield build
+    finally:
+        LibreNMSClient._instance = None
+        LibreNMSClient._initialized = False
+
+
+@pytest.mark.asyncio
+async def test_non_json_body_reports_the_status_code(mock_client):
+    """A proxy error page must not surface as a bare JSON decode error."""
+    client = mock_client(
+        lambda _request: httpx.Response(502, text="<html>502 Bad Gateway</html>")
+    )
+
+    with pytest.raises(RuntimeError, match="HTTP 502"):
+        await client.get("devices")
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_librenms_json_errors_are_returned_not_raised(mock_client):
+    """LibreNMS reports its own errors as JSON, which is more useful than the code."""
+    client = mock_client(
+        lambda _request: httpx.Response(
+            404, json={"status": "error", "message": "Device foo not found"}
+        )
+    )
+
+    assert await client.get("devices/foo") == {
+        "status": "error",
+        "message": "Device foo not found",
+    }
+
+    await client.close()


### PR DESCRIPTION
request() decoded every body as JSON with the status check commented out, so a response that is not JSON at all - a reverse proxy error page, for instance - surfaced as {"error": "Expecting value: line 1 column 1 (char 0)"} with no indication of what went wrong.

Raise a RuntimeError carrying the method, path, status code and a snippet of the body instead. LibreNMS' own JSON errors are still returned rather than raised, since their message is more useful to the caller than the code, and that behaviour is now covered by a test.

Also drop get_librenms_client() and its module-level singleton: no tool ever called it, every one constructs LibreNMSClient(config) directly.