### PR TITLE
fix(oxidized): paginate config search on the nodes key

### DIFF
--- a/src/librenms_mcp/tools/oxidized.py
+++ b/src/librenms_mcp/tools/oxidized.py
@@ -161,9 +161,10 @@ def register_oxidized_tools(mcp, config):
                 result = await client.get(
                     f"oxidized/config/search/{quote(search, safe='')}"
                 )
+                # LibreNMS returns the matches under "nodes".
                 if isinstance(result, list):
-                    result = {"results": result}
-                return paginate_list(result, limit, offset, key="results")
+                    result = {"nodes": result}
+                return paginate_list(result, limit, offset, key="nodes")
 
         except Exception as e:
             await ctx.error(f"Error searching Oxidized configs: {e!s}")


### PR DESCRIPTION
LibreNMS returns Oxidized config search matches under "nodes", but the tool asked paginate_list for "results". paginate_list returns the payload untouched when its key is absent, so limit and offset were silently ignored and every call dumped every match across all stored configs.