### PR TITLE
fix(bills): return bill graphs as images

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,10 +304,10 @@ empty graph type.
 
 - `bills_list`: List bills
 - `bill_get`: Get details for a bill
-- `bill_graph`: Get bill graph
+- `bill_graph`: Render a bill graph as an image
 - `bill_graph_data`: Get bill graph data
 - `bill_history`: Get bill history
-- `bill_history_graph`: Get bill history graph
+- `bill_history_graph`: Render a bill history graph as an image
 - `bill_history_graph_data`: Get bill history graph data
 - `bill_create_or_update`: Create or update a bill
 - `bill_delete`: Delete a bill

--- a/src/librenms_mcp/tools/bills.py
+++ b/src/librenms_mcp/tools/bills.py
@@ -5,10 +5,13 @@ LibreNMS MCP Server Bill Tools
 from typing import Annotated
 from typing import Any
 
+from fastmcp.exceptions import ToolError
 from fastmcp.server.context import Context
+from fastmcp.utilities.types import Image
 from pydantic import Field
 
 from librenms_mcp.librenms_client import LibreNMSClient
+from librenms_mcp.tools.graphs import _to_image
 from librenms_mcp.utils import paginate_list
 
 
@@ -143,26 +146,35 @@ def register_bill_tools(mcp, config):
             Field(description="Graph type: bits, monthly, hour, or day"),
         ],
         ctx: Context,
-    ) -> dict:
+    ) -> Image:
         """
-        Get bill graph image from LibreNMS.
+        Render a bill graph as an image.
+
+        For the underlying numbers rather than a picture, use bill_graph_data.
 
         Args:
             bill_id (int): Bill ID.
             graph_type (str): Type of graph (bits, monthly, hour, day).
 
         Returns:
-            dict: The JSON response from the API.
+            Image: The rendered graph.
         """
         try:
             await ctx.info(f"Getting bill graph {bill_id}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(f"bills/{bill_id}/graphs/{graph_type}")
+                data, content_type = await client.get_raw(
+                    f"bills/{bill_id}/graphs/{graph_type}"
+                )
+                return _to_image(data, content_type)
 
+        except ToolError:
+            raise
         except Exception as e:
             await ctx.error(f"Error bill graph {bill_id}: {e!s}")
-            return {"error": str(e)}
+            raise ToolError(
+                f"Could not render the {graph_type} graph for bill {bill_id}: {e!s}"
+            ) from e
 
     @mcp.tool(
         tags={"librenms", "bills", "read-only"},
@@ -266,9 +278,12 @@ def register_bill_tools(mcp, config):
             Field(description="Graph type: bits, monthly, hour, or day"),
         ],
         ctx: Context,
-    ) -> dict:
+    ) -> Image:
         """
-        Get bill history graph from LibreNMS.
+        Render a graph for a past billing period as an image.
+
+        For the underlying numbers rather than a picture, use
+        bill_history_graph_data.
 
         Args:
             bill_id (int): Bill ID.
@@ -276,19 +291,25 @@ def register_bill_tools(mcp, config):
             graph_type (str): Type of graph (bits, monthly, hour, day).
 
         Returns:
-            dict: The JSON response from the API.
+            Image: The rendered graph.
         """
         try:
             await ctx.info(f"Getting bill history graph {bill_id}...")
 
             async with LibreNMSClient(config) as client:
-                return await client.get(
+                data, content_type = await client.get_raw(
                     f"bills/{bill_id}/history/{history_id}/graphs/{graph_type}"
                 )
+                return _to_image(data, content_type)
 
+        except ToolError:
+            raise
         except Exception as e:
             await ctx.error(f"Error bill history graph {bill_id}: {e!s}")
-            return {"error": str(e)}
+            raise ToolError(
+                f"Could not render the {graph_type} graph for bill {bill_id} "
+                f"history {history_id}: {e!s}"
+            ) from e
 
     @mcp.tool(
         tags={"librenms", "bills", "read-only"},

--- a/tests/test_bill_graphs.py
+++ b/tests/test_bill_graphs.py
@@ -1,0 +1,86 @@
+"""Guards for the bill graph tools.
+
+The bill graph endpoints answer with a rendered image, not JSON, so they have
+to go through get_raw. Decoding them as JSON fails on every call.
+"""
+
+from typing import Any
+
+import pytest
+from fastmcp.utilities.types import Image
+
+from librenms_mcp.tools import bills as bills_module
+
+
+class _FakeContext:
+    """Stands in for the FastMCP context the tools log through."""
+
+    async def info(self, message: str) -> None:
+        pass
+
+    async def error(self, message: str) -> None:
+        pass
+
+
+class _FakeClient:
+    """Records requests and replays a canned image response."""
+
+    def __init__(self, raw: tuple[bytes, str]):
+        self.raw = raw
+        self.calls: list[tuple[str, str, Any]] = []
+
+    def __call__(self, _config):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    async def get_raw(self, path: str, params: dict | None = None):
+        self.calls.append(("GET", path, params))
+        return self.raw
+
+
+class _ToolRecorder:
+    """Captures the tools a register_* function declares."""
+
+    def __init__(self):
+        self.tools: dict[str, Any] = {}
+
+    def tool(self, **kwargs):  # noqa: ARG002
+        def decorator(fn):
+            self.tools[fn.__name__] = fn
+            return fn
+
+        return decorator
+
+
+@pytest.fixture
+def bill_tools() -> _ToolRecorder:
+    recorder = _ToolRecorder()
+    bills_module.register_bill_tools(recorder, None)
+    return recorder
+
+
+@pytest.mark.asyncio
+async def test_bill_graph_returns_an_image(bill_tools, monkeypatch):
+    fake = _FakeClient((b"\x89PNG", "image/png"))
+    monkeypatch.setattr(bills_module, "LibreNMSClient", fake)
+
+    image = await bill_tools.tools["bill_graph"](4, "bits", _FakeContext())
+
+    assert isinstance(image, Image)
+    assert fake.calls == [("GET", "bills/4/graphs/bits", None)]
+
+
+@pytest.mark.asyncio
+async def test_bill_history_graph_returns_an_image(bill_tools, monkeypatch):
+    fake = _FakeClient((b"<svg/>", "image/svg+xml"))
+    monkeypatch.setattr(bills_module, "LibreNMSClient", fake)
+
+    image = await bill_tools.tools["bill_history_graph"](4, 9, "day", _FakeContext())
+
+    assert isinstance(image, Image)
+    assert fake.calls == [("GET", "bills/4/history/9/graphs/day", None)]


### PR DESCRIPTION
The bill graph endpoints render an image, so decoding the body as JSON failed on every call and both tools always returned {"error": "Expecting value: line 1 column 1 (char 0)"}.

Fetch them with get_raw and return an Image, matching how the device and port graph tools already work. The graphdata endpoints are genuinely JSON and are left alone.