### PR TITLE
fix(config): treat blank env vars as unset

### DIFF
--- a/src/librenms_mcp/utils.py
+++ b/src/librenms_mcp/utils.py
@@ -7,16 +7,23 @@ def parse_bool(val: str | None, default: bool = True) -> bool:
     """
     Convert a value to boolean.
 
+    A blank or whitespace-only value counts as unset and yields the default,
+    so an env var declared without a value (``LIBRENMS_VERIFY_SSL=``) cannot
+    silently flip a setting off.
+
     Args:
         val: The value to convert.
-        default (bool, optional): The default value to return if val is None. Defaults to True.
+        default (bool, optional): The default value to return if val is None or blank. Defaults to True.
 
     Returns:
         bool: True if val represents a truthy value ("1", "true", "yes", "on"), case-insensitive; otherwise False.
     """
     if val is None:
         return default
-    return str(val).strip().casefold() in TRUTHY_VALUES
+    normalized = str(val).strip().casefold()
+    if not normalized:
+        return default
+    return normalized in TRUTHY_VALUES
 
 
 def paginate_list(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,10 +20,13 @@ from librenms_mcp.utils import parse_bool
         ("false", True, False),
         ("no", True, False),
         ("off", True, False),
-        ("", True, False),
         ("random", True, False),
-        ("  ", True, False),
         ("False", True, False),
+        # Blank means "unset", so the default wins rather than False.
+        ("", True, True),
+        ("", False, False),
+        ("  ", True, True),
+        ("  ", False, False),
     ],
 )
 def test_parse_bool(val, default, expected):


### PR DESCRIPTION
A declared-but-empty env var such as LIBRENMS_VERIFY_SSL= resolved to False instead of the documented default, silently disabling TLS certificate verification. parse_bool now falls back to the default for blank and whitespace-only values.